### PR TITLE
Fix issue with unclosed file descriptors

### DIFF
--- a/python/r2pipe/open_base.py
+++ b/python/r2pipe/open_base.py
@@ -178,7 +178,9 @@ class OpenBase(object):
                         import subprocess
                         is_async = not isinstance(self.process, subprocess.Popen)
                         if not is_async:
-                                self.process.stdin.flush()
+                                for f in [self.process.stdin, self.process.stdout]:
+                                        if f is not None:
+                                                f.close()
                         self.process.terminate()
                         self.process.wait()
                         delattr(self, 'process')


### PR DESCRIPTION
```
/usr/local/lib/python3.7/site-packages/r2pipe/open_base.py:188: ResourceWarning: unclosed file <_io.FileIO name=4 mode='wb' closefd=True>
  delattr(self, 'process')
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/usr/local/lib/python3.7/site-packages/r2pipe/open_base.py:188: ResourceWarning: unclosed file <_io.FileIO name=5 mode='rb' closefd=True>
  delattr(self, 'process')
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```