### PR TITLE
More precise filename parsing in python module. Closes #114.

### DIFF
--- a/python/r2pipe/open_async.py
+++ b/python/r2pipe/open_async.py
@@ -49,7 +49,7 @@ class open(OpenBase, ContextDecorator):
 
                 self.asyn = True
 
-                if filename.startswith("http"):
+                if filename.startswith("http://"):
                         self._cmd_coro = self._cmd_http
                         self.uri = "/cmd"
 
@@ -61,7 +61,7 @@ class open(OpenBase, ContextDecorator):
                         self._cmd_coro = self._cmd_native
                         self.uri = filename[7:]
 
-                elif filename.startswith("tcp"):
+                elif filename.startswith("tcp://"):
 
                         r = re.match(r'tcp://(\d+\.\d+.\d+.\d+):(\d+)/?', filename)
                         if not r:

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -30,13 +30,13 @@ class open(OpenBase):
                 
         def __init__(self, filename='', flags=[], radare2home=None):
                 super(open, self).__init__(filename, flags)
-                if filename.startswith("http"):
+                if filename.startswith("http://"):
                         self._cmd = self._cmd_http
                         self.uri = filename + "/cmd"
                 elif filename.startswith("ccall://"):
                         self._cmd = self._cmd_native
                         self.uri = filename[7:]
-                elif filename.startswith("tcp"):
+                elif filename.startswith("tcp://"):
                         r = re.match(r'tcp://(\d+\.\d+.\d+.\d+):(\d+)/?', filename)
                         if not r:
                                 raise Exception("String doesn't match tcp format")


### PR DESCRIPTION
**Detailed description**

Previously, python module would check if filename started with "tcp"
or "http." This would cause weird edge cases where a relative path
starting with a directory called "tcp" or "http" would cause an
exception to be thrown. This checks for filenames that start with
"tcp://" or "http://" instead, which *might* still cause the same
issue but is less likely.

**Test plan**

Confirm that this fixes #114 while not breaking existing "tcp" and "http" functionality.

Open http r2pipe still works: https://asciinema.org/a/mMoiuX7wCc8WWyugLeoiUMDLJ

Open tcp r2pipe doesn't work, but it doesn't work with old version either (will open separate issue maybe): https://asciinema.org/a/LPOQr085xo4qLx6qN3NdetFPO

Show fix to #114: https://asciinema.org/a/hfCV8YcaSPyvwR2ifQHY7VpQr 


**Closing issues**

Closes #114 