### PR TITLE
r2pipe - drop python 2 support, fix python 3

### DIFF
--- a/python/dbgtest.py
+++ b/python/dbgtest.py
@@ -2,8 +2,8 @@
 
 import r2pipe
 
-r2=r2pipe.open("/bin/ls", ["-nd"])
-for a in range(1,10):
-	regs = r2.cmdj("drj")
-	print("0x%x  0x%x" % (regs['rip'],regs['rsp']))
-	r2.cmd("ds")
+r2 = r2pipe.open("/bin/ls", ["-nd"])
+for a in range(1, 10):
+    regs = r2.cmdj("drj")
+    print("0x%x  0x%x" % (regs["rip"], regs["rsp"]))
+    r2.cmd("ds")

--- a/python/dbgtest.py
+++ b/python/dbgtest.py
@@ -1,7 +1,9 @@
+#!/usr/bin/env python3
+
 import r2pipe
 
 r2=r2pipe.open("/bin/ls", ["-nd"])
 for a in range(1,10):
 	regs = r2.cmdj("drj")
-	print "0x%x  0x%x"%(regs['rip'],regs['rsp'])
+	print("0x%x  0x%x" % (regs['rip'],regs['rsp']))
 	r2.cmd("ds")

--- a/python/examples/010-to-r2.py
+++ b/python/examples/010-to-r2.py
@@ -7,46 +7,44 @@ import pfp
 import sys
 import os
 
-if len(sys.argv)>1:
-	template = sys.argv[1]
-	try:
-		binfile = os.environ["FILE"]
-	except:
-		try:
-			binfile = sys.argv[2]
-		except:
-			print "Missing file to parse"
-			sys.exit(1)
+if len(sys.argv) > 1:
+    template = sys.argv[1]
+    try:
+        binfile = os.environ["FILE"]
+    except:
+        try:
+            binfile = sys.argv[2]
+        except:
+            print "Missing file to parse"
+            sys.exit(1)
 else:
-	print "Usage: 010-to-r2.py [template.bt] ([file])"
-	print "> .!python 010-to-r2.py JPEGTemplate.bt"
-	sys.exit(1)
+    print "Usage: 010-to-r2.py [template.bt] ([file])"
+    print "> .!python 010-to-r2.py JPEGTemplate.bt"
+    sys.exit(1)
 
 # XXX pfp.parse show noisy messages
-dom = pfp.parse (
-	data_file = binfile,
-	template_file = template
-)
+dom = pfp.parse(data_file=binfile, template_file=template)
+
+
 def filterFlagName(x):
-	x = x.replace("[","_")
-	x = x.replace("]","_")
-	return x
+    x = x.replace("[", "_")
+    x = x.replace("]", "_")
+    return x
+
 
 rows = dom._pfp__show(include_offset=True)
 structName = ""
 for line in rows.split("\n"):
-	isStruct = line.find("struct") != -1
-	line = line.strip()
-	line = line.split("=")[0]
-	if line[0] == "}":
-		continue
-	line = "0x" + line
-	cols = line.split(" ")
-	if isStruct:
-		structName = cols[1]
-	else:
-		fn = structName + "." + cols[1]
-		flagName = "struct." + filterFlagName(fn)
-		print "f "+ flagName + " = " + cols[0]
-
-
+    isStruct = line.find("struct") != -1
+    line = line.strip()
+    line = line.split("=")[0]
+    if line[0] == "}":
+        continue
+    line = "0x" + line
+    cols = line.split(" ")
+    if isStruct:
+        structName = cols[1]
+    else:
+        fn = structName + "." + cols[1]
+        flagName = "struct." + filterFlagName(fn)
+        print "f " + flagName + " = " + cols[0]

--- a/python/examples/bug.py
+++ b/python/examples/bug.py
@@ -1,31 +1,34 @@
 import sys
 import r2pipe
 
-err=0
+err = 0
+
 
 def test(msg, a, b):
-	global err
-	sys.stdout.write("%s  "%(msg))
-	a = a.strip()
-	b = b.strip()
-	if a == b:
-		print("ok")
-	else:
-		err = err + 1
-		print("FAIL")
+    global err
+    sys.stdout.write("%s  " % (msg))
+    a = a.strip()
+    b = b.strip()
+    if a == b:
+        print("ok")
+    else:
+        err = err + 1
+        print("FAIL")
+
 
 def verify(title, cmd, expected):
-	r2 = r2pipe.open("-")
-	msg = r2.cmd(cmd)
-	test(title, msg, expected)
-	r2.quit()
+    r2 = r2pipe.open("-")
+    msg = r2.cmd(cmd)
+    test(title, msg, expected)
+    r2.quit()
+
 
 verify("Test #1", "?e hello", "hello")
 verify("Test #2", "?e hello\n", "hello")
 verify("Test #3", "?e hello\n?e world", "hello\nworld")
 verify("Test #4", "?e hello;?e world", "hello\nworld")
 verify("Test #5", "?e hello\n", "hello")
-verify("Test #6", "?e hello\n\n;\n\n?e world", "hello\nworld") # known to fail
+verify("Test #6", "?e hello\n\n;\n\n?e world", "hello\nworld")  # known to fail
 verify("Test #7", "?e hello\n", "hello")
 verify("Test #8", "?e hello;;;;;?e world", "hello\nworld")
 

--- a/python/examples/libgraph.py
+++ b/python/examples/libgraph.py
@@ -3,57 +3,64 @@ import sys
 import os
 
 r2 = r2pipe.open("/bin/ls")
-libpath = ['', '.', '/lib', '/usr/lib']
-output = 'aa'
+libpath = ["", ".", "/lib", "/usr/lib"]
+output = "aa"
 # output = 'dot'
 
 done = {}
 
+
 def findlib(lib):
-	if os.path.isfile(lib):
-		return lib
-	for a in libpath:
-		if os.path.isfile("%s/%s"%(a, lib)):
-			return "%s/%s"%(a, lib)
-	return []
+    if os.path.isfile(lib):
+        return lib
+    for a in libpath:
+        if os.path.isfile("%s/%s" % (a, lib)):
+            return "%s/%s" % (a, lib)
+    return []
+
 
 def getlibs(lib):
-	return r2.syscmdj("rabin2 -lj %s"%(lib))['libs']
+    return r2.syscmdj("rabin2 -lj %s" % (lib))["libs"]
+
 
 def filter(s):
-	return s.replace("-","_").replace("+","x")
+    return s.replace("-", "_").replace("+", "x")
+
 
 def makeNode(name):
-	r2.cmd("agn %s"%(filter(name)))
+    r2.cmd("agn %s" % (filter(name)))
 
-def makeEdge(f,t):
-	r2.cmd("age %s %s"%(filter(f), filter(t)))
+
+def makeEdge(f, t):
+    r2.cmd("age %s %s" % (filter(f), filter(t)))
+
 
 def graphlibs(src, root):
-	hs = src.replace("/","_")
-	hs = hs.replace("-","_")
-	hs = hs.replace("+","x")
-	try:
-		if done[hs]:
-			return;
-	except:
-		done[hs] = True
-	src = findlib(src)
-	makeNode(src)
-	for lib in getlibs(src):
-		lib = findlib(lib)
-		makeNode(lib)
-		makeEdge(src, lib)
-		graphlibs(lib, src)
+    hs = src.replace("/", "_")
+    hs = hs.replace("-", "_")
+    hs = hs.replace("+", "x")
+    try:
+        if done[hs]:
+            return
+    except:
+        done[hs] = True
+    src = findlib(src)
+    makeNode(src)
+    for lib in getlibs(src):
+        lib = findlib(lib)
+        makeNode(lib)
+        makeEdge(src, lib)
+        graphlibs(lib, src)
+
 
 if len(sys.argv) > 1:
-	path = sys.argv[1]
-	graphlibs(path, None)
-	if output == "dot":
-		print r2.cmd("aggd")
-	else:
-		print r2.cmd("e scr.color=true;agg")
-	r2.quit()
+    path = sys.argv[1]
+    graphlibs(path, None)
+    if output == "dot":
+        print r2.cmd("aggd")
+    else:
+        print r2.cmd("e scr.color=true;agg")
+    r2.quit()
 else:
-	print "Usage: libgraph.py [path-to-bin]"
-	sys.exit(1)
+    print "Usage: libgraph.py [path-to-bin]"
+    sys.exit(1)

--- a/python/examples/sync/talkto.py
+++ b/python/examples/sync/talkto.py
@@ -18,17 +18,17 @@
 import r2pipe
 
 try:
-	r2 = r2pipe.open()
-	r2.cmd("e cfg.user=pancake")
-	r2.cmd("e cfg.log=true")
+    r2 = r2pipe.open()
+    r2.cmd("e cfg.user=pancake")
+    r2.cmd("e cfg.log=true")
 
-	r2.cmd("T this is me")
-	r2.cmd("CC hello world")
-	logs = r2.cmd("T")
-	print(logs)
+    r2.cmd("T this is me")
+    r2.cmd("CC hello world")
+    logs = r2.cmd("T")
+    print (logs)
 except:
-	print ("You need r2pm -i lang-python")
-	pass
+    print ("You need r2pm -i lang-python")
+    pass
 
 last = ""
 last2 = ""
@@ -36,46 +36,50 @@ r2r = r2pipe.open("http://localhost:9090")
 r2r.cmd("e cfg.log=true")
 print r2r.cmd("o")
 
+
 def pull():
-	global last2
-	print "PULL"
-	items = r2r.cmdj("Tj%s"%(last2))
-	print "Syncing %s"%(last2)
-	if len(items) > 0:
-		print "ITEMS"
-		for (id, msg) in items:
-			print ("MUST RUN IN LOCAL %s"%(msg))
-			r2.cmd("e cfg.log=0")
-			r2.cmd(msg[1:])
-			r2.cmd("e cfg.log=1")
-			if id > last2 or last2 == "":
-				last2 = id
-		last2 = last2 + 1
+    global last2
+    print "PULL"
+    items = r2r.cmdj("Tj%s" % (last2))
+    print "Syncing %s" % (last2)
+    if len(items) > 0:
+        print "ITEMS"
+        for (id, msg) in items:
+            print ("MUST RUN IN LOCAL %s" % (msg))
+            r2.cmd("e cfg.log=0")
+            r2.cmd(msg[1:])
+            r2.cmd("e cfg.log=1")
+            if id > last2 or last2 == "":
+                last2 = id
+        last2 = last2 + 1
+
 
 def runmsg(msg):
-	if msg[0] == ':':
-		print("RUN REMOTE %s"%(msg))
-		r2r.cmd(msg[1:])
-	elif msg[0] == '<':
-		print("CHAT %s"%(msg))
-	else:
-		print("UNK %s"%(msg))
+    if msg[0] == ":":
+        print ("RUN REMOTE %s" % (msg))
+        r2r.cmd(msg[1:])
+    elif msg[0] == "<":
+        print ("CHAT %s" % (msg))
+    else:
+        print ("UNK %s" % (msg))
+
 
 def sync():
-	global last
-	print "Syncing %s"%(last)
-	items = r2.cmdj("Tj%s"%(last))
-	if len(items) > 0:
-		print "ITEMS"
-		for (id, msg) in items:
-			runmsg(msg)
-			if id > last or last == "":
-				last = id
-		last = last + 1
-		print ("LAST %s"%(last))
-	pull()
+    global last
+    print "Syncing %s" % (last)
+    items = r2.cmdj("Tj%s" % (last))
+    if len(items) > 0:
+        print "ITEMS"
+        for (id, msg) in items:
+            runmsg(msg)
+            if id > last or last == "":
+                last = id
+        last = last + 1
+        print ("LAST %s" % (last))
+    pull()
+
 
 # initialize
-r2.cmd("\"e cmd.log=#!python -e sync()\"")
-r2.cmd("\"e cmd.prompt=#!python -e sync()\"")
-r2.cmd("\"e cmd.vprompt=#!python -e sync()\"")
+r2.cmd('"e cmd.log=#!python -e sync()"')
+r2.cmd('"e cmd.prompt=#!python -e sync()"')
+r2.cmd('"e cmd.vprompt=#!python -e sync()"')

--- a/python/examples/syscall/int.py
+++ b/python/examples/syscall/int.py
@@ -5,13 +5,13 @@ import r2pipe
 r2p = r2pipe.open()
 num = int(sys.argv[1])
 if num == 0x80:
-	r = r2p.cmdj("arj")
-	if r['eax'] == 1:
-		print "[SYSCALL EXIT] %d"%(r['ebx'])
-	elif r['eax'] == 4:
-		msg = r2p.cmd("psz %d@%d"%(r['edx'], r['ecx']))
-		print "[WRITE SYSCALL] ==> %s"%(msg)
+    r = r2p.cmdj("arj")
+    if r["eax"] == 1:
+        print "[SYSCALL EXIT] %d" % (r["ebx"])
+    elif r["eax"] == 4:
+        msg = r2p.cmd("psz %d@%d" % (r["edx"], r["ecx"]))
+        print "[WRITE SYSCALL] ==> %s" % (msg)
 elif num == 3:
-	print "[INT3]"
+    print "[INT3]"
 else:
-	print ("[unhandled SYSCALL %d]"%num)
+    print ("[unhandled SYSCALL %d]" % num)

--- a/python/examples/test-backends.py
+++ b/python/examples/test-backends.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+# /usr/bin/env python
 
 import r2pipe
 from os import system
@@ -6,18 +6,18 @@ import time
 
 if __name__ == "__main__":
     print("[+] Spawning r2 tcp and http servers")
-    system ("pkill r2")
-    system ("radare2 -qc.:9080 /bin/ls &")
-    system ("radare2 -qc=h /bin/ls &")
+    system("pkill r2")
+    system("radare2 -qc.:9080 /bin/ls &")
+    system("radare2 -qc=h /bin/ls &")
     time.sleep(1)
 
     # Test r2pipe with local process
     print("[+] Testing python r2pipe local")
     rlocal = r2pipe.open("/bin/ls")
     print(rlocal.cmd("pi 5"))
-    #print rlocal.cmd("pn")
+    # print rlocal.cmd("pn")
     info = rlocal.cmdj("ij")
-    print ("Architecture: " + info['bin']['machine'])
+    print("Architecture: " + info["bin"]["machine"])
 
     # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
     print("[+] Testing python r2pipe tcp://")
@@ -36,4 +36,4 @@ if __name__ == "__main__":
         print("Error with remote http conection")
     else:
         print(disas)
-    system ("pkill -INT r2")
+    system("pkill -INT r2")

--- a/python/examples/test.py
+++ b/python/examples/test.py
@@ -2,22 +2,22 @@ import os
 import sys
 import r2pipe
 
-curdir=os.path.dirname(os.path.realpath(__file__))
+curdir = os.path.dirname(os.path.realpath(__file__))
 
 r2 = r2pipe.open(curdir + "/ls", ["-2"])
 
-#print(r2pipe.__file__)
-#print(r2pipe.VERSION)
+# print(r2pipe.__file__)
+# print(r2pipe.VERSION)
 
-r2.cmd('aa')
+r2.cmd("aa")
 
 sys.stdout.write("/bin/ls    ")
 
 pi1 = r2.cmd("pi 1 @e:scr.color=0").strip()
 if pi1 == "push rbp":
-	print("OK")
+    print("OK")
 else:
-	print("FAIL")
-#print(pi1)
-#print (r2.cmd("pd 10"));
+    print("FAIL")
+# print(pi1)
+# print (r2.cmd("pd 10"));
 r2.quit()

--- a/python/except.py
+++ b/python/except.py
@@ -5,16 +5,16 @@ import sys
 
 r = r2pipe.open("/bin/ls")
 try:
-	print ("r2 version: %s"%r.cmd("?V"))
-	pid = int(r.cmd("?vi $p"))
-	print ("Killing r2 PID %d"%(pid))
-	r.cmd("\"!(sleep 1; kill -9 %d) &\""%pid)
-	r.cmd("!sleep 3")
-	print(r.cmd("x"))
-	r.cmd("q")
-	print ("This was not expected!")
+    print("r2 version: %s" % r.cmd("?V"))
+    pid = int(r.cmd("?vi $p"))
+    print("Killing r2 PID %d" % (pid))
+    r.cmd('"!(sleep 1; kill -9 %d) &"' % pid)
+    r.cmd("!sleep 3")
+    print(r.cmd("x"))
+    r.cmd("q")
+    print("This was not expected!")
 except:
-	print ("r2 was killed as expected")
-	sys.exit(0)
+    print("r2 was killed as expected")
+    sys.exit(0)
 
 sys.exit(1)

--- a/python/except.py
+++ b/python/except.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import r2pipe
 import sys
 

--- a/python/ipython.py
+++ b/python/ipython.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Author: pancake@nopcode.org // radare2 2015
 #
@@ -62,12 +62,12 @@ class Radare:
 				address = str(address)
 			if len(arg)>1:
 				count = arg[1]
-		print self.r2.cmd("e scr.color=true;pd %d @ %s"%(count,address))
+		print(self.r2.cmd("e scr.color=true;pd %d @ %s"%(count,address)))
 		return self
 	def hexdump(self, address, count):
 		if type(address) == int:
 			address = str(address)
-		print self.r2.cmd("e scr.color=true;px %d @ %s"%(count,address))
+		print(self.r2.cmd("e scr.color=true;px %d @ %s"%(count,address)))
 		return self
 
 

--- a/python/ipython.py
+++ b/python/ipython.py
@@ -12,66 +12,81 @@ import IPython
 
 r2 = None
 try:
-	pipes = [ int(os.environ['R2PIPE_IN']), int(os.environ['R2PIPE_OUT']) ]
-	r2 = r2pipe.open("#!pipe")
+    pipes = [int(os.environ["R2PIPE_IN"]), int(os.environ["R2PIPE_OUT"])]
+    r2 = r2pipe.open("#!pipe")
 except:
-	print ("This script must be run from inside r2:")
-	print (" $ r2 -qi ipython.py /bin/ls")
-	sys.exit(1)
+    print("This script must be run from inside r2:")
+    print(" $ r2 -qi ipython.py /bin/ls")
+    sys.exit(1)
 
 
 class RadareBin:
-	r2 = None
-	def __init__(self, r2):
-		self.r2 = r2
-		self.baddr = 0
-		self.filename = r2.cmd('i~file:0[1]').strip()
-	def imports(self):
-		if self.baddr != 0:
-			return self.r2.syscmdj("rabin2 -B %d -ij '%s'"%(self.baddr, self.filename))['imports']
-		else:
-			return self.r2.syscmdj("rabin2 -ij '%s'"%(self.filename))['imports']
-	def symbols(self):
-		if self.baddr != 0:
-			return self.r2.syscmdj("rabin2 -B %d -sj '%s'"%(self.baddr, self.filename))['symbols']
-		else:
-			return self.r2.syscmdj("rabin2 -sj '%s'"%(self.filename))['symbols']
-	def entries(self):
-		if self.baddr != 0:
-			return self.r2.syscmdj("rabin2 -B %d -ej '%s'"%(self.baddr, self.filename))['entries']
-		else:
-			return self.r2.syscmdj("rabin2 -ej '%s'"%(self.filename))['entries']
+    r2 = None
+
+    def __init__(self, r2):
+        self.r2 = r2
+        self.baddr = 0
+        self.filename = r2.cmd("i~file:0[1]").strip()
+
+    def imports(self):
+        if self.baddr != 0:
+            return self.r2.syscmdj(
+                "rabin2 -B %d -ij '%s'" % (self.baddr, self.filename)
+            )["imports"]
+        else:
+            return self.r2.syscmdj("rabin2 -ij '%s'" % (self.filename))["imports"]
+
+    def symbols(self):
+        if self.baddr != 0:
+            return self.r2.syscmdj(
+                "rabin2 -B %d -sj '%s'" % (self.baddr, self.filename)
+            )["symbols"]
+        else:
+            return self.r2.syscmdj("rabin2 -sj '%s'" % (self.filename))["symbols"]
+
+    def entries(self):
+        if self.baddr != 0:
+            return self.r2.syscmdj(
+                "rabin2 -B %d -ej '%s'" % (self.baddr, self.filename)
+            )["entries"]
+        else:
+            return self.r2.syscmdj("rabin2 -ej '%s'" % (self.filename))["entries"]
+
 
 class Radare:
-	r2 = None
-	Bin = None
-	def __init__(self, r2):
-		self.r2 = r2
-		self.Bin = RadareBin(r2)
-	def seek(self, address):
-		if type(address) == int:
-			address = str(address)
-		self.r2.cmd ("s %s"%(address))
-		return self
-	def disasm(self, *arg): #address, count):
-		address = ''
-		count = 16
-		if len(arg)>0:
-			address = arg[0]
-			if type(address) == int:
-				address = str(address)
-			if len(arg)>1:
-				count = arg[1]
-		print(self.r2.cmd("e scr.color=true;pd %d @ %s"%(count,address)))
-		return self
-	def hexdump(self, address, count):
-		if type(address) == int:
-			address = str(address)
-		print(self.r2.cmd("e scr.color=true;px %d @ %s"%(count,address)))
-		return self
+    r2 = None
+    Bin = None
+
+    def __init__(self, r2):
+        self.r2 = r2
+        self.Bin = RadareBin(r2)
+
+    def seek(self, address):
+        if type(address) == int:
+            address = str(address)
+        self.r2.cmd("s %s" % (address))
+        return self
+
+    def disasm(self, *arg):  # address, count):
+        address = ""
+        count = 16
+        if len(arg) > 0:
+            address = arg[0]
+            if type(address) == int:
+                address = str(address)
+            if len(arg) > 1:
+                count = arg[1]
+        print(self.r2.cmd("e scr.color=true;pd %d @ %s" % (count, address)))
+        return self
+
+    def hexdump(self, address, count):
+        if type(address) == int:
+            address = str(address)
+        print(self.r2.cmd("e scr.color=true;px %d @ %s" % (count, address)))
+        return self
 
 
-r = Radare (r2)
+r = Radare(r2)
 r.disasm("entry0", 10)
 r.hexdump("entry0", 10)
 

--- a/python/lang-pipe.py
+++ b/python/lang-pipe.py
@@ -3,7 +3,7 @@ import r2pipe
 
 r2 = r2pipe.open("#!pipe")
 
-_dis = r2.cmd ("pd 5")
+_dis = r2.cmd("pd 5")
 print(_dis)
-_hex = r2.cmd ("px 64")
+_hex = r2.cmd("px 64")
 print(_hex)

--- a/python/lang-pipe.py
+++ b/python/lang-pipe.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import r2pipe
 
 r2 = r2pipe.open("#!pipe")

--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """r2pipe

--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -29,9 +29,9 @@ import sys
 import time
 
 try:
-        import r2lang
+    import r2lang
 except ImportError:
-        r2lang = None
+    r2lang = None
 
 VERSION = "1.4.2"
 
@@ -39,109 +39,110 @@ from .open_sync import open
 
 
 def version():
-        """Return string with the version of the r2pipe library
+    """Return string with the version of the r2pipe library
         """
-        return VERSION
+    return VERSION
+
 
 """open class is now in open_base.py"""
 
 # Hello World
 if __name__ == "__main__":
 
-        print("[+] Spawning r2 tcp and http servers")
-        os.system("pkill r2")
-        os.system("radare2 -qc.:9080 /bin/ls &")
-        os.system("radare2 -qc=h /bin/ls &")
-        time.sleep(1)
+    print("[+] Spawning r2 tcp and http servers")
+    os.system("pkill r2")
+    os.system("radare2 -qc.:9080 /bin/ls &")
+    os.system("radare2 -qc=h /bin/ls &")
+    time.sleep(1)
 
-        if sys.version_info <= (3, 0):
-                # Test r2pipe with local process
-                print("[+] Testing python r2pipe local")
-                rlocal = open("/bin/ls")
-                print(rlocal.cmd("pi 5"))
-                # print rlocal.cmd("pn")
-                info = rlocal.cmdj("ij")
-                print("Architecture: " + info['bin']['machine'])
+    if sys.version_info <= (3, 0):
+        # Test r2pipe with local process
+        print("[+] Testing python r2pipe local")
+        rlocal = open("/bin/ls")
+        print(rlocal.cmd("pi 5"))
+        # print rlocal.cmd("pn")
+        info = rlocal.cmdj("ij")
+        print("Architecture: " + info["bin"]["machine"])
 
-                # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
-                print("[+] Testing python r2pipe tcp://")
-                rremote = open("tcp://127.0.0.1:9080")
-                disas = rremote.cmd("pi 5")
-                if not disas:
-                        print("Error with remote tcp conection")
-                else:
-                        print(disas)
-
-                # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
-                print("[+] Testing python r2pipe http://")
-                rremote = open("http://127.0.0.1:9090")
-                disas = rremote.cmd("pi 5")
-                if not disas:
-                        print("Error with remote http conection")
-                else:
-                        print(disas)
+        # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
+        print("[+] Testing python r2pipe tcp://")
+        rremote = open("tcp://127.0.0.1:9080")
+        disas = rremote.cmd("pi 5")
+        if not disas:
+            print("Error with remote tcp conection")
         else:
-                # --------------------------------------------------------------------------
-                # Python 3 examples, with non-blocking API and callbacks
-                # --------------------------------------------------------------------------
-                def callback(result):
-                        print(result)
+            print(disas)
 
-                #
-                # Test r2pipe with local process
-                #
-                #   Start 1 task
-                print("[+] Testing python r2pipe local")
-                rlocal = open("/bin/ls")
-                t = rlocal.cmd("pi 5", callback=callback)
-                rlocal.wait(t)  # Wait for task end
-                info = rlocal.cmdj("ij")
-                rlocal.wait(info)
-                print("Architecture: " + info['bin']['machine'])
-                rlocal.close()
-                #   Start 3 tasks with Context manager
-                print("[+] Testing python r2pipe local with 3 queries")
-                with open("/bin/ls") as rlocall:
-                        t1 = rlocall.cmd("pi 5", callback=callback)
-                        t2 = rlocall.cmd("pi 5", callback=callback)
-                        t3 = rlocall.cmd("pi 5", callback=callback)
-                        rlocall.wait([t1, t2, t3])
+        # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
+        print("[+] Testing python r2pipe http://")
+        rremote = open("http://127.0.0.1:9090")
+        disas = rremote.cmd("pi 5")
+        if not disas:
+            print("Error with remote http conection")
+        else:
+            print(disas)
+    else:
+        # --------------------------------------------------------------------------
+        # Python 3 examples, with non-blocking API and callbacks
+        # --------------------------------------------------------------------------
+        def callback(result):
+            print(result)
 
-                #
-                # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
-                #
-                #   Start 1 task
-                print("[+] Testing python r2pipe tcp://")
-                rremote = open("tcp://127.0.0.1:9080")
-                t = rremote.cmd("pi 5",callback=callback)
-                rremote.wait(t)
-                rremote.close()
+        #
+        # Test r2pipe with local process
+        #
+        #   Start 1 task
+        print("[+] Testing python r2pipe local")
+        rlocal = open("/bin/ls")
+        t = rlocal.cmd("pi 5", callback=callback)
+        rlocal.wait(t)  # Wait for task end
+        info = rlocal.cmdj("ij")
+        rlocal.wait(info)
+        print("Architecture: " + info["bin"]["machine"])
+        rlocal.close()
+        #   Start 3 tasks with Context manager
+        print("[+] Testing python r2pipe local with 3 queries")
+        with open("/bin/ls") as rlocall:
+            t1 = rlocall.cmd("pi 5", callback=callback)
+            t2 = rlocall.cmd("pi 5", callback=callback)
+            t3 = rlocall.cmd("pi 5", callback=callback)
+            rlocall.wait([t1, t2, t3])
 
-                #   Start 3 tasks with Context manager
-                print("[+] Testing python r2pipe tcp:// with 3 queries")
-                with open("tcp://127.0.0.1:9080") as rremote:
-                        t1 = rremote.cmd("pi 5", callback=callback)
-                        t2 = rremote.cmd("pi 5", callback=callback)
-                        t3 = rremote.cmd("pi 5", callback=callback)
+        #
+        # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
+        #
+        #   Start 1 task
+        print("[+] Testing python r2pipe tcp://")
+        rremote = open("tcp://127.0.0.1:9080")
+        t = rremote.cmd("pi 5", callback=callback)
+        rremote.wait(t)
+        rremote.close()
 
-                        rremote.wait([t1, t2, t3])
+        #   Start 3 tasks with Context manager
+        print("[+] Testing python r2pipe tcp:// with 3 queries")
+        with open("tcp://127.0.0.1:9080") as rremote:
+            t1 = rremote.cmd("pi 5", callback=callback)
+            t2 = rremote.cmd("pi 5", callback=callback)
+            t3 = rremote.cmd("pi 5", callback=callback)
 
-                #
-                # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
-                #
-                print("[+] Testing python r2pipe http://")
-                rremote = open("tcp://127.0.0.1:9080")
-                t = rremote.cmd("pi 5", callback=callback)
-                rremote.wait(t)
-                rremote.close()
+            rremote.wait([t1, t2, t3])
 
-                #   Start 3 tasks with Context manager
-                print("[+] Testing python r2pipe http:// with 3 queries")
-                with open("http://127.0.0.1:9090") as rremote:
-                        t1 = rremote.cmd("pi 10", callback=callback)
-                        t2 = rremote.cmd("pi 5", callback=callback)
-                        t3 = rremote.cmd("pi 5", callback=callback)
+        #
+        # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
+        #
+        print("[+] Testing python r2pipe http://")
+        rremote = open("tcp://127.0.0.1:9080")
+        t = rremote.cmd("pi 5", callback=callback)
+        rremote.wait(t)
+        rremote.close()
 
-                        rremote.wait([t1, t2, t3])
+        #   Start 3 tasks with Context manager
+        print("[+] Testing python r2pipe http:// with 3 queries")
+        with open("http://127.0.0.1:9090") as rremote:
+            t1 = rremote.cmd("pi 10", callback=callback)
+            t2 = rremote.cmd("pi 5", callback=callback)
+            t3 = rremote.cmd("pi 5", callback=callback)
 
-        os.system("pkill -INT radare2")
+            rremote.wait([t1, t2, t3])
+
+    os.system("pkill -INT radare2")

--- a/python/r2pipe/native.py
+++ b/python/r2pipe/native.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys

--- a/python/r2pipe/native.py
+++ b/python/r2pipe/native.py
@@ -6,110 +6,113 @@ from ctypes import Structure, addressof, c_char_p, c_void_p
 from ctypes.util import find_library
 
 try:
-	from ctypes import CDLL
+    from ctypes import CDLL
 except:
-	pass
+    pass
 
 try:
-	from ctypes import WinDLL
+    from ctypes import WinDLL
 except:
-	pass
+    pass
 
-lib_name = find_library('r_core')
+lib_name = find_library("r_core")
 if lib_name == None:
-	raise ImportError("No native r_core library")
+    raise ImportError("No native r_core library")
 
-if sys.platform.startswith('win'):
-	lib = WinDLL(lib_name)
+if sys.platform.startswith("win"):
+    lib = WinDLL(lib_name)
 else:
-	lib = CDLL(lib_name)
+    lib = CDLL(lib_name)
 
 
 class AddressHolder(object):
-	def __get__(self, obj, type_):
-		if getattr(obj, '_address', None) is None:
-			obj._address = addressof(obj)
-		return obj._address
+    def __get__(self, obj, type_):
+        if getattr(obj, "_address", None) is None:
+            obj._address = addressof(obj)
+        return obj._address
 
-	def __set__(self, obj, value):
-		obj._address = value
+    def __set__(self, obj, value):
+        obj._address = value
 
 
 class WrappedRMethod(object):
-	def __init__(self, cname, args, ret):
-		self.cname = cname
-		self.args = args
-		self.ret = ret
-		self.args_set = False
-		self.method = getattr(lib, cname)
+    def __init__(self, cname, args, ret):
+        self.cname = cname
+        self.args = args
+        self.ret = ret
+        self.args_set = False
+        self.method = getattr(lib, cname)
 
-	def __call__(self, *a):
-		if not self.args_set:
-			if self.args:
-				self.method.argtypes = [eval(x.strip()) for x in self.args.split(',')]
-			self.method.restype = eval(self.ret) if self.ret else None
-			self.args_set = True
-		a = list(a)
-		for i, argt in enumerate(self.method.argtypes):
-			if argt is c_char_p:
-				a[i] = a[i].encode()
-		if self.method.restype is c_char_p:
-			return self.method(*a).decode()
-		return self.method(*a)
+    def __call__(self, *a):
+        if not self.args_set:
+            if self.args:
+                self.method.argtypes = [eval(x.strip()) for x in self.args.split(",")]
+            self.method.restype = eval(self.ret) if self.ret else None
+            self.args_set = True
+        a = list(a)
+        for i, argt in enumerate(self.method.argtypes):
+            if argt is c_char_p:
+                a[i] = a[i].encode()
+        if self.method.restype is c_char_p:
+            return self.method(*a).decode()
+        return self.method(*a)
 
 
 class WrappedApiMethod(object):
-	def __init__(self, method, ret2, last):
-		self.method = method
-		self._o = None
-		self.ret2 = ret2
-		self.last = last
+    def __init__(self, method, ret2, last):
+        self.method = method
+        self._o = None
+        self.ret2 = ret2
+        self.last = last
 
-	def __call__(self, *a):
-		result = self.method(self._o, *a)
-		if self.ret2:
-			if self.ret2 == 'c_char_p':
-				return result
-			else:
-				result = eval(self.ret2)(result)
-		if self.last:
-			return getattr(result, self.last)
-		return result
+    def __call__(self, *a):
+        result = self.method(self._o, *a)
+        if self.ret2:
+            if self.ret2 == "c_char_p":
+                return result
+            else:
+                result = eval(self.ret2)(result)
+        if self.last:
+            return getattr(result, self.last)
+        return result
 
-	def __get__(self, obj, type_):
-		self._o = obj._o
-		return self
+    def __get__(self, obj, type_):
+        self._o = obj._o
+        return self
 
 
 def register(cname, args, ret):
-	ret2 = last = None
-	if ret:
-		if ret[0] >= 'A' and ret[0] <= 'Z':
-			x = ret.find('<')
-			if x != -1:
-				ret = ret[0:x]
-			last = 'contents'
-			ret = 'POINTER(' + ret + ')'
-		else:
-			last = 'value'
-			ret2 = ret
+    ret2 = last = None
+    if ret:
+        if ret[0] >= "A" and ret[0] <= "Z":
+            x = ret.find("<")
+            if x != -1:
+                ret = ret[0:x]
+            last = "contents"
+            ret = "POINTER(" + ret + ")"
+        else:
+            last = "value"
+            ret2 = ret
 
-	method = WrappedRMethod(cname, args, ret)
-	wrapped_method = WrappedApiMethod(method, ret2, last)
-	return wrapped_method, method
+    method = WrappedRMethod(cname, args, ret)
+    wrapped_method = WrappedApiMethod(method, ret2, last)
+    return wrapped_method, method
 
 
 class RCore(Structure):  # 1
-	def __init__(self):
-		Structure.__init__(self)
-		r_core_new = lib.r_core_new
-		r_core_new.restype = c_void_p
-		self._o = r_core_new()
+    def __init__(self):
+        Structure.__init__(self)
+        r_core_new = lib.r_core_new
+        r_core_new.restype = c_void_p
+        self._o = r_core_new()
 
-	_o = AddressHolder()
+    _o = AddressHolder()
 
-	cmd_str, r_core_cmd_str = register('r_core_cmd_str', 'c_void_p, c_char_p', 'c_char_p')
-	free, r_core_free = register('r_core_free', 'c_void_p', 'c_void_p')
+    cmd_str, r_core_cmd_str = register(
+        "r_core_cmd_str", "c_void_p, c_char_p", "c_char_p"
+    )
+    free, r_core_free = register("r_core_free", "c_void_p", "c_void_p")
+
 
 #  c = RCore()
 #  c.cmd_str("o /bin/ls")

--- a/python/r2pipe/open_async.py
+++ b/python/r2pipe/open_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""open_async.py 
+"""open_async.py
 This script use code from r2pipe-async/open_p3.py script.
 
 """

--- a/python/r2pipe/open_async.py
+++ b/python/r2pipe/open_async.py
@@ -17,200 +17,206 @@ from urllib.parse import quote, urlparse
 
 from .open_base import OpenBase, get_radare_path
 
+
 class open(OpenBase, ContextDecorator):
-        # --------------------------------------------------------------------------
-        # Contenxt manager functions
-        # --------------------------------------------------------------------------
-        def __enter__(self):
-                return self
+    # --------------------------------------------------------------------------
+    # Contenxt manager functions
+    # --------------------------------------------------------------------------
+    def __enter__(self):
+        return self
 
-        def __exit__(self, *exc):
-                self.close()
-                return False
+    def __exit__(self, *exc):
+        self.close()
+        return False
 
-        def close(self):
-                if self._loop.is_running():
-                        self._loop.stop()
-                if not self._loop.is_closed():
-                        self._loop.close()
+    def close(self):
+        if self._loop.is_running():
+            self._loop.stop()
+        if not self._loop.is_closed():
+            self._loop.close()
 
-        def __init__(self, filename='', flags=[], radare2home=None):
-                super(open, self).__init__(filename, flags)
+    def __init__(self, filename="", flags=[], radare2home=None):
+        super(open, self).__init__(filename, flags)
 
-                self.r2home = radare2home
+        self.r2home = radare2home
 
-                if os.name == 'nt':
-                        self._loop = asyncio.ProactorEventLoop()
-                        asyncio.set_event_loop(self._loop)
-                else:
-                        watcher = asyncio.get_child_watcher()
-                        self._loop = asyncio.new_event_loop()
-                        watcher.attach_loop(self._loop)
+        if os.name == "nt":
+            self._loop = asyncio.ProactorEventLoop()
+            asyncio.set_event_loop(self._loop)
+        else:
+            watcher = asyncio.get_child_watcher()
+            self._loop = asyncio.new_event_loop()
+            watcher.attach_loop(self._loop)
 
-                self.asyn = True
+        self.asyn = True
 
-                if filename.startswith("http://"):
-                        self._cmd_coro = self._cmd_http
-                        self.uri = "/cmd"
+        if filename.startswith("http://"):
+            self._cmd_coro = self._cmd_http
+            self.uri = "/cmd"
 
-                        _tmp = urlparse(filename)
-                        self._host = _tmp.hostname
-                        self._port = _tmp.port
+            _tmp = urlparse(filename)
+            self._host = _tmp.hostname
+            self._port = _tmp.port
 
-                elif filename.startswith("ccall://"):
-                        self._cmd_coro = self._cmd_native
-                        self.uri = filename[7:]
+        elif filename.startswith("ccall://"):
+            self._cmd_coro = self._cmd_native
+            self.uri = filename[7:]
 
-                elif filename.startswith("tcp://"):
+        elif filename.startswith("tcp://"):
 
-                        r = re.match(r'tcp://(\d+\.\d+.\d+.\d+):(\d+)/?', filename)
-                        if not r:
-                                raise Exception("String doesn't match tcp format")
+            r = re.match(r"tcp://(\d+\.\d+.\d+.\d+):(\d+)/?", filename)
+            if not r:
+                raise Exception("String doesn't match tcp format")
 
-                        self._cmd_coro = self._cmd_tcp
-                        self._host = r.group(1)
-                        self._port = r.group(2)
+            self._cmd_coro = self._cmd_tcp
+            self._host = r.group(1)
+            self._port = r.group(2)
 
-                elif filename:
+        elif filename:
 
-                        self._cmd_coro = self._cmd_process
+            self._cmd_coro = self._cmd_process
 
-                        cmd = ["-q0", filename]
-                        cmd = cmd[:1] + flags + cmd[1:]
-                        self._process_start_cmd = cmd
+            cmd = ["-q0", filename]
+            cmd = cmd[:1] + flags + cmd[1:]
+            self._process_start_cmd = cmd
 
-                else:
-                        self.asyn = False
+        else:
+            self.asyn = False
 
+    def _callback_wrapper(self, future):
+        result, callback = future.result()
 
-        def _callback_wrapper(self, future):
-                result, callback = future.result()
+        if callback:
+            callback(result)
 
-                if callback:
-                        callback(result)
+    def _cmd(self, cmd, **kwargs):
+        # Get callback, if available
+        callback = kwargs.get("callback")
+        future = asyncio.Future(loop=self._loop)
+        future.add_done_callback(self._callback_wrapper)
 
-        def _cmd(self, cmd, **kwargs):
-                # Get callback, if available
-                callback = kwargs.get("callback")
-                future = asyncio.Future(loop=self._loop)
-                future.add_done_callback(self._callback_wrapper)
+        task = self._loop.create_task(self._cmd_coro(cmd, future, callback))
 
-                task = self._loop.create_task(self._cmd_coro(cmd, future, callback))
+        # Create and start a new task (coroutine)
+        self._loop.run_until_complete(task)
+        return task.result() if task else None
 
-                # Create and start a new task (coroutine)
-                self._loop.run_until_complete(task)
-                return task.result() if task else None
+    @asyncio.coroutine
+    def _cmd_process(self, cmd, future, callback):
+        if not hasattr(self, "process"):
+            if self.r2home is not None:
+                if not os.path.isdir(self.r2home):
+                    raise Exception(
+                        "`radare2home` passed to `open` is invalid, leave it None or put a valid path to r2 folder"
+                    )
+                r2path = os.path.join(self.r2home, "radare2")
+                if os.name == "nt":
+                    r2path += ".exe"
+            else:
+                r2path = get_radare_path()
 
-        @asyncio.coroutine
-        def _cmd_process(self, cmd, future, callback):
-                if not hasattr(self, 'process'):
-                        if self.r2home is not None:
-                                if not os.path.isdir(self.r2home):
-                                        raise Exception('`radare2home` passed to `open` is invalid, leave it None or put a valid path to r2 folder')
-                                r2path = os.path.join(self.r2home, 'radare2')
-                                if os.name == 'nt':
-                                        r2path += '.exe'
-                        else:
-                                r2path = get_radare_path()
+            create = asyncio.create_subprocess_exec(
+                r2path,
+                *self._process_start_cmd,
+                shell=False,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                loop=self._loop
+            )
 
-                        create = asyncio.create_subprocess_exec(r2path,
-                                                                *self._process_start_cmd,
-                                                                shell=False,
-                                                                stdin=asyncio.subprocess.PIPE,
-                                                                stdout=asyncio.subprocess.PIPE,
-                                                                loop=self._loop)
+            self.process = yield from create  # Init the process
 
-                        self.process = yield from create  # Init the process
+            yield from self.process.stdout.read(1)  # Reads initial \x00
 
-                        yield from self.process.stdout.read(1)  # Reads initial \x00
+        cmd = cmd.strip().replace("\n", ";")
+        self.process.stdin.write(bytes(cmd + "\n", "utf-8"))
 
-                cmd = cmd.strip().replace("\n", ";")
-                self.process.stdin.write(bytes(cmd + '\n', 'utf-8'))
+        out = []
+        while True:
+            # foo = self.process.stdout.read(1)
+            foo = yield from self.process.stdout.read(1)
+            if foo == b"\x00":
+                break
+            if len(foo) < 1:
+                return None
+            out.append(foo)
 
-                out = []
-                while True:
-                        # foo = self.process.stdout.read(1)
-                        foo = yield from self.process.stdout.read(1)
-                        if foo == b'\x00':
-                                break
-                        if len(foo) < 1:
-                                return None
-                        out.append(foo)
+        out = b"".join(out).decode("utf-8")
+        future.set_result((out, callback))
+        return out
 
-                out = b"".join(out).decode('utf-8')
-                future.set_result((out, callback))
-                return out
+    @asyncio.coroutine
+    def _cmd_http(self, cmd, future, callback):
+        try:
+            quocmd = quote(cmd)
 
-        @asyncio.coroutine
-        def _cmd_http(self, cmd, future, callback):
-                try:
-                        quocmd = quote(cmd)
+            reader, writer = yield from asyncio.open_connection(
+                self._host, self._port, loop=self._loop
+            )
 
-                        reader, writer = yield from asyncio.open_connection(self._host,
-                                                                            self._port,
-                                                                            loop=self._loop)
+            message = "\n\r".join(
+                [
+                    "GET /cmd/%s HTTP/1.1" % quocmd,
+                    "Host: %s:%s" % (self._host, self._port),
+                    "User-Agent: r2pipe/Python Client",
+                    "Accept: */*",
+                    "",
+                    "",
+                ]
+            ).encode()
 
-                        message = "\n\r".join([
-                                'GET /cmd/%s HTTP/1.1' % quocmd,
-                                'Host: %s:%s' % (self._host, self._port),
-                                'User-Agent: r2pipe/Python Client',
-                                'Accept: */*',
-                                '',
-                                ''
-                        ]).encode()
+            writer.write(message)
+            data = yield from reader.read(512)
+            res = [data]
+            while data:
+                data = yield from reader.read(512)
+                res.append(data)
+            writer.close()
 
-                        writer.write(message)
-                        data = yield from reader.read(512)
-                        res = [data]
-                        while data:
-                                data = yield from reader.read(512)
-                                res.append(data)
-                        writer.close()
+            res = b"".join(res)
 
-                        res = b''.join(res)
+            # Remove http headers
+            start = 0
+            for x in res.splitlines():
+                if not x:
+                    start += 1
+                    break
+                start += len(x) + 1  # +1 because we must be count '\n'
+            res = res[start:].decode("utf-8")
+            future.set_result((res, callback))
+            return res
 
-                        # Remove http headers
-                        start = 0
-                        for x in res.splitlines():
-                                if not x:
-                                        start += 1
-                                        break
-                                start += len(x) + 1  # +1 because we must be count '\n'
-                        res = res[start:].decode('utf-8')
-                        future.set_result((res, callback))
-                        return res
+        except Exception as e:
+            future.set_result((str(e), callback))
 
-                except Exception as e:
-                        future.set_result((str(e), callback))
+    @asyncio.coroutine
+    def _cmd_tcp(self, cmd, future, callback):
 
-        @asyncio.coroutine
-        def _cmd_tcp(self, cmd, future, callback):
+        try:
+            reader, writer = yield from asyncio.open_connection(
+                self._host, self._port, loop=self._loop
+            )
 
-                try:
-                        reader, writer = yield from asyncio.open_connection(self._host,
-                                                                            self._port,
-                                                                            loop=self._loop)
+            writer.write(cmd.encode("utf-8"))
+            data = yield from reader.read(512)
 
-                        writer.write(cmd.encode('utf-8'))
-                        data = yield from reader.read(512)
+            res = [data]
+            while data:
+                res.append(data)
+                data = yield from reader.read(512)
+            res = b"".join(res).decode("utf-8")
+            future.set_result((res, callback))
+            writer.close()
+            return res
 
-                        res = [data]
-                        while data:
-                                res.append(data)
-                                data = yield from reader.read(512)
-                        res = b''.join(res).decode('utf-8')
-                        future.set_result((res, callback))
-                        writer.close()
-                        return res
+        except Exception as e:
+            future.set_result((str(e), callback))
 
-                except Exception as e:
-                        future.set_result((str(e), callback))
+    def wait(self, task):
+        """Wait until task finish"""
+        _tasks = task
+        if not isinstance(task, Iterable):
+            _tasks = [task]
 
-        def wait(self, task):
-                """Wait until task finish"""
-                _tasks = task
-                if not isinstance(task, Iterable):
-                        _tasks = [task]
-
-                if self._loop.is_running():
-                        asyncio.wait(_tasks, loop=self._loop)
+        if self._loop.is_running():
+            asyncio.wait(_tasks, loop=self._loop)

--- a/python/r2pipe/open_base.py
+++ b/python/r2pipe/open_base.py
@@ -1,4 +1,4 @@
-# /usr/bin/env python
+# /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """open_base.py

--- a/python/r2pipe/open_base.py
+++ b/python/r2pipe/open_base.py
@@ -15,76 +15,86 @@ import platform
 from subprocess import Popen, PIPE
 
 try:
-	import r2lang
+    import r2lang
 except ImportError:
-	r2lang = None
+    r2lang = None
 try:
-        from .native import RCore
-        has_native = True
+    from .native import RCore
+
+    has_native = True
 except ImportError:
-        has_native = False
+    has_native = False
 
 if os.name == "nt":
-	from ctypes import byref, c_ulong, create_string_buffer, windll
-	import msvcrt
-	GENERIC_READ = 0x80000000
-	GENERIC_WRITE = 0x40000000
-	OPEN_EXISTING = 0x3
-	INVALID_HANDLE_VALUE = -1
-	PIPE_READMODE_MESSAGE = 0x2
-	ERROR_PIPE_BUSY = 231
-	ERROR_MORE_DATA = 234
-	BUFSIZE = 4096
-	szPipename = "\\\\.\\pipe\\"
-	chBuf = create_string_buffer(BUFSIZE)
-	cbRead = c_ulong(0)
-	cbWritten = c_ulong(0)
+    from ctypes import byref, c_ulong, create_string_buffer, windll
+    import msvcrt
+
+    GENERIC_READ = 0x80000000
+    GENERIC_WRITE = 0x40000000
+    OPEN_EXISTING = 0x3
+    INVALID_HANDLE_VALUE = -1
+    PIPE_READMODE_MESSAGE = 0x2
+    ERROR_PIPE_BUSY = 231
+    ERROR_MORE_DATA = 234
+    BUFSIZE = 4096
+    szPipename = "\\\\.\\pipe\\"
+    chBuf = create_string_buffer(BUFSIZE)
+    cbRead = c_ulong(0)
+    cbWritten = c_ulong(0)
 
 
 def in_rlang():
-	return r2lang is not None and r2lang.cmd is not None
+    return r2lang is not None and r2lang.cmd is not None
+
 
 def jo2po(jo):
-	from collections import namedtuple
-	def _json_object_hook(d): return namedtuple('X', d.keys(), rename=True)(*d.values())
-	def json2obj(data): return json.loads(data, object_hook=_json_object_hook)
-	return json2obj(jo)
+    from collections import namedtuple
+
+    def _json_object_hook(d):
+        return namedtuple("X", d.keys(), rename=True)(*d.values())
+
+    def json2obj(data):
+        return json.loads(data, object_hook=_json_object_hook)
+
+    return json2obj(jo)
+
 
 def get_radare_path():
-	try:
-		which = shutil.which
-	except AttributeError:
-		# In python 2 doesn't exist which function
-		from distutils.spawn import find_executable
+    try:
+        which = shutil.which
+    except AttributeError:
+        # In python 2 doesn't exist which function
+        from distutils.spawn import find_executable
 
-		which = find_executable
+        which = find_executable
 
-	bin_file = which("radare2")
+    bin_file = which("radare2")
 
-	if bin_file and os.path.isfile(bin_file):
-		return bin_file
-	else:
-		_platform = platform.system().lower()
+    if bin_file and os.path.isfile(bin_file):
+        return bin_file
+    else:
+        _platform = platform.system().lower()
 
-		if _platform.startswith("darwin"):
-			bin_file = "/usr/local/bin/radare2"
-		else:
-			bin_file = "/usr/bin/radare2"
+        if _platform.startswith("darwin"):
+            bin_file = "/usr/local/bin/radare2"
+        else:
+            bin_file = "/usr/bin/radare2"
 
-		if os.path.isfile(bin_file):
-			return bin_file
-		else:
-			raise IOError("radare2 can't be found in your system")
+        if os.path.isfile(bin_file):
+            return bin_file
+        else:
+            raise IOError("radare2 can't be found in your system")
 
 
 class OpenBase(object):
-        """Class representing an r2pipe connection with a running radare2 instance
+    """Class representing an r2pipe connection with a running radare2 instance
         Class body derived from __init__.py "open" class.
     
     
         """
-        def __init__(self, filename='', flags=[]):
-                """Open a new r2 pipe
+
+    def __init__(self, filename="", flags=[]):
+        """Open a new r2 pipe
                 The 'filename' can be one of the following:
 
                 * absolute or relative path to file
@@ -99,99 +109,117 @@ class OpenBase(object):
                 Returns:
                     Returns an object with methods to interact with r2 via commands
                 """
-                self.asyn = False
-                if not filename and in_rlang():
-                        self._cmd = self._cmd_rlang
+        self.asyn = False
+        if not filename and in_rlang():
+            self._cmd = self._cmd_rlang
+            return
+        try:
+            if os.name == "nt":
+                mypipename = os.environ["r2pipe_path"]
+                while 1:
+                    hPipe = windll.kernel32.CreateFileA(
+                        szPipename + mypipename,
+                        GENERIC_READ | GENERIC_WRITE,
+                        0,
+                        None,
+                        OPEN_EXISTING,
+                        0,
+                        None,
+                    )
+                    if hPipe != INVALID_HANDLE_VALUE:
+                        break
+                    else:
+                        print("Invalid Handle Value")
+                    if windll.kernel32.GetLastError() != ERROR_PIPE_BUSY:
+                        print("Could not open pipe")
                         return
-                try:
-                        if os.name == "nt":
-                                mypipename = os.environ['r2pipe_path']
-                                while 1:
-                                        hPipe = windll.kernel32.CreateFileA(szPipename + mypipename, GENERIC_READ | GENERIC_WRITE, 0, None, OPEN_EXISTING, 0, None)
-                                        if (hPipe != INVALID_HANDLE_VALUE):
-                                                break
-                                        else:
-                                                print("Invalid Handle Value")
-                                        if (windll.kernel32.GetLastError() != ERROR_PIPE_BUSY):
-                                                print("Could not open pipe")
-                                                return
-                                        elif ((windll.kernel32.WaitNamedPipeA(szPipename, 20000)) == 0):
-                                                print("Could not open pipe\n")
-                                                return
-                                windll.kernel32.WriteFile(hPipe, "e scr.color=false\n", 18, byref(cbWritten), None)
-                                windll.kernel32.ReadFile(hPipe, chBuf, BUFSIZE, byref(cbRead), None)
-                                self.pipe = [hPipe, hPipe]
-                                self._cmd = self._cmd_pipe
-                        else:
-                                self.pipe = [int(os.environ['R2PIPE_IN']), int(os.environ['R2PIPE_OUT'])]
-                                self._cmd = self._cmd_pipe
-                        self.url = "#!pipe"
+                    elif (windll.kernel32.WaitNamedPipeA(szPipename, 20000)) == 0:
+                        print("Could not open pipe\n")
                         return
-                except:
-                        pass
-                if filename.startswith("#!pipe"):
-                        raise Exception("ERROR: Cannot use #!pipe without R2PIPE_{IN|OUT} env")
+                windll.kernel32.WriteFile(
+                    hPipe, "e scr.color=false\n", 18, byref(cbWritten), None
+                )
+                windll.kernel32.ReadFile(hPipe, chBuf, BUFSIZE, byref(cbRead), None)
+                self.pipe = [hPipe, hPipe]
+                self._cmd = self._cmd_pipe
+            else:
+                self.pipe = [
+                    int(os.environ["R2PIPE_IN"]),
+                    int(os.environ["R2PIPE_OUT"]),
+                ]
+                self._cmd = self._cmd_pipe
+            self.url = "#!pipe"
+            return
+        except:
+            pass
+        if filename.startswith("#!pipe"):
+            raise Exception("ERROR: Cannot use #!pipe without R2PIPE_{IN|OUT} env")
 
-
-        def _cmd_pipe(self, cmd):
-                out = b''
-                cmd = cmd.strip().replace("\n", ";")
-                if os.name == "nt":
-                        windll.kernel32.WriteFile(self.pipe[1], cmd, len(cmd), byref(cbWritten), None)
-                        while True:
-                                windll.kernel32.ReadFile(self.pipe[1], chBuf, BUFSIZE, byref(cbRead), None)
-                                out += chBuf.value
-                                if ord(chBuf[cbRead.value - 1]) == 0:
-                                        out = out[0:-1]
-                                        break
+    def _cmd_pipe(self, cmd):
+        out = b""
+        cmd = cmd.strip().replace("\n", ";")
+        if os.name == "nt":
+            windll.kernel32.WriteFile(
+                self.pipe[1], cmd, len(cmd), byref(cbWritten), None
+            )
+            while True:
+                windll.kernel32.ReadFile(
+                    self.pipe[1], chBuf, BUFSIZE, byref(cbRead), None
+                )
+                out += chBuf.value
+                if ord(chBuf[cbRead.value - 1]) == 0:
+                    out = out[0:-1]
+                    break
+        else:
+            os.write(self.pipe[1], cmd.encode())
+            while True:
+                res = os.read(self.pipe[0], 4096)
+                if len(res) < 1:
+                    break
+                if res[-1] == b"\x00"[0]:
+                    out += res[0:-1]
                 else:
-                        os.write(self.pipe[1], cmd.encode())
-                        while True:
-                                res = os.read(self.pipe[0], 4096)
-                                if (len(res) < 1):
-                                        break
-                                if res[-1] == b'\x00'[0]:
-                                        out += res[0:-1]
-                                else:
-                                        out += res
-                                if (len(res) < 4096):
-                                        break
-                return out.decode('utf-8')
+                    out += res
+                if len(res) < 4096:
+                    break
+        return out.decode("utf-8")
 
-        def _cmd_native(self, cmd):
-                cmd = cmd.strip().replace("\n", ";")
-                if not has_native:
-                        raise Exception('No native ctypes connector available')
-                if not hasattr(self, 'native'):
-                        self.native = RCore()
-                        self.native.cmd_str("o " + self.uri)
-                return self.native.cmd_str(cmd)
+    def _cmd_native(self, cmd):
+        cmd = cmd.strip().replace("\n", ";")
+        if not has_native:
+            raise Exception("No native ctypes connector available")
+        if not hasattr(self, "native"):
+            self.native = RCore()
+            self.native.cmd_str("o " + self.uri)
+        return self.native.cmd_str(cmd)
 
-        def _cmd_rlang(self, cmd):
-                return r2lang.cmd(cmd)
-     
-        def quit(self):
-                """Quit current r2pipe session and kill
+    def _cmd_rlang(self, cmd):
+        return r2lang.cmd(cmd)
+
+    def quit(self):
+        """Quit current r2pipe session and kill
                 """
-                self.cmd("q")
-                if hasattr(self, 'process'):
-                        import subprocess
-                        is_async = not isinstance(self.process, subprocess.Popen)
-                        if not is_async:
-                                for f in [self.process.stdin, self.process.stdout]:
-                                        if f is not None:
-                                                f.close()
-                        self.process.terminate()
-                        self.process.wait()
-                        delattr(self, 'process')
+        self.cmd("q")
+        if hasattr(self, "process"):
+            import subprocess
 
-                        if is_async:
-                                import asyncio
-                                asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.1))
+            is_async = not isinstance(self.process, subprocess.Popen)
+            if not is_async:
+                for f in [self.process.stdin, self.process.stdout]:
+                    if f is not None:
+                        f.close()
+            self.process.terminate()
+            self.process.wait()
+            delattr(self, "process")
 
-        # r2 commands
-        def cmd(self, cmd, **kwargs):
-                """Run an r2 command return string with result
+            if is_async:
+                import asyncio
+
+                asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.1))
+
+    # r2 commands
+    def cmd(self, cmd, **kwargs):
+        """Run an r2 command return string with result
                 Args:
                     cmd (str): r2 command
                 Returns:
@@ -202,64 +230,63 @@ class OpenBase(object):
                     return res.strip()
                 return None
                 """
-                
-                res = self._cmd(cmd, **kwargs)
-                if res is not None:
-                        return res
-                return None
-            
-        def cmdj(self, cmd, **kwargs):
-                """Same as cmd() but evaluates JSONs and returns an object
+
+        res = self._cmd(cmd, **kwargs)
+        if res is not None:
+            return res
+        return None
+
+    def cmdj(self, cmd, **kwargs):
+        """Same as cmd() but evaluates JSONs and returns an object
                 Args:
                     cmdj (str): r2 command
                 Returns:
                     Returns a JSON object respresenting the parsed JSON
                 """
-                result = self.cmd(cmd, **kwargs)
+        result = self.cmd(cmd, **kwargs)
 
-                try:
-                        data = json.loads(result)
-                except (ValueError, KeyError, TypeError) as e:
-                        sys.stderr.write("r2pipe.cmdj.Error: %s\n" % (e))
-                        data = None
-                return data
+        try:
+            data = json.loads(result)
+        except (ValueError, KeyError, TypeError) as e:
+            sys.stderr.write("r2pipe.cmdj.Error: %s\n" % (e))
+            data = None
+        return data
 
-        def cmdJ(self, cmd, **kwargs):
-                """Same as cmdj() but evaluates into a native Python Object
+    def cmdJ(self, cmd, **kwargs):
+        """Same as cmdj() but evaluates into a native Python Object
                 Args:
                     cmdJ (str): r2 command
                 Returns:
                     Returns a Python object respresenting the parsed JSON
                 """
-                result = self.cmd(cmd, **kwargs)
-                try:
-                        return jo2po(result)
-                except (ValueError, KeyError, TypeError) as e:
-                        sys.stderr.write("r2pipe.cmdj.Error: %s\n" % (e))
-                return None
+        result = self.cmd(cmd, **kwargs)
+        try:
+            return jo2po(result)
+        except (ValueError, KeyError, TypeError) as e:
+            sys.stderr.write("r2pipe.cmdj.Error: %s\n" % (e))
+        return None
 
-        def syscmd(self, cmd):
-                """Executes a program and returns the output (stdout only)
+    def syscmd(self, cmd):
+        """Executes a program and returns the output (stdout only)
                 Args:
                     cmd (str): commandline shell command
                 Returns:
                     Returns a string with the output
                 """
-                p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE)
-                out, err = p.communicate()
-                return out
+        p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE)
+        out, err = p.communicate()
+        return out
 
-        def syscmdj(self, cmd):
-                """Executes a program and returns an object representing the parsed JSON of the output
+    def syscmdj(self, cmd):
+        """Executes a program and returns an object representing the parsed JSON of the output
                 Args:
                     cmd (str): commandline shell command
                 Returns:
                     Returns an object constructed by parsing the JSON returned by the command
                 """
-                try:
-                        data = json.loads(self.syscmd(cmd))
-                except (ValueError, KeyError, TypeError) as e:
-                        sys.stderr.write("r2pipe.syscmdj.Error %s\n" % (e))
-                        data = None
-                return data
-
+        try:
+            data = json.loads(self.syscmd(cmd))
+        except (ValueError, KeyError, TypeError) as e:
+            sys.stderr.write("r2pipe.syscmdj.Error %s\n" % (e))
+            data = None
+        return data

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -18,126 +18,130 @@ from urllib.request import urlopen
 from urllib.error import URLError
 
 try:
-        import fcntl
+    import fcntl
 except ImportError:
-        fcntl = None
+    fcntl = None
 
 
 class open(OpenBase):
+    def __init__(self, filename="", flags=[], radare2home=None):
+        super(open, self).__init__(filename, flags)
+        if filename.startswith("http://"):
+            self._cmd = self._cmd_http
+            self.uri = filename + "/cmd"
+        elif filename.startswith("ccall://"):
+            self._cmd = self._cmd_native
+            self.uri = filename[7:]
+        elif filename.startswith("tcp://"):
+            r = re.match(r"tcp://(\d+\.\d+.\d+.\d+):(\d+)/?", filename)
+            if not r:
+                raise Exception("String doesn't match tcp format")
+            self._cmd = self._cmd_tcp
+            self.conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.conn.connect((r.group(1), int(r.group(2))))
+        elif filename:
+            self._cmd = self._cmd_process
+            if radare2home is not None:
+                if not os.path.isdir(radare2home):
+                    raise Exception(
+                        "`radare2home` passed is invalid, leave it None or put a valid path to r2 folder"
+                    )
+                r2e = os.path.join(radare2home, "radare2")
+            else:
+                r2e = "radare2"
+            if os.name == "nt":
+                # avoid errors on Windows when subprocess messes with name
+                r2e += ".exe"
+            cmd = [r2e, "-q0", filename]
+            cmd = cmd[:1] + flags + cmd[1:]
+            try:
+                self.process = Popen(
+                    cmd, shell=False, stdin=PIPE, stdout=PIPE, bufsize=0
+                )
+            except:
+                raise Exception("ERROR: Cannot find radare2 in PATH")
+            self.process.stdout.read(1)  # Reads initial \x00
+            # make it non-blocking to speedup reading
+            self.nonblocking = True
+            if self.nonblocking:
+                fd = self.process.stdout.fileno()
+                if not self.__make_non_blocking(fd):
+                    Exception("ERROR: Cannot make stdout pipe non-blocking")
 
-        def __init__(self, filename='', flags=[], radare2home=None):
-                super(open, self).__init__(filename, flags)
-                if filename.startswith("http://"):
-                        self._cmd = self._cmd_http
-                        self.uri = filename + "/cmd"
-                elif filename.startswith("ccall://"):
-                        self._cmd = self._cmd_native
-                        self.uri = filename[7:]
-                elif filename.startswith("tcp://"):
-                        r = re.match(r'tcp://(\d+\.\d+.\d+.\d+):(\d+)/?', filename)
-                        if not r:
-                                raise Exception("String doesn't match tcp format")
-                        self._cmd = self._cmd_tcp
-                        self.conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                        self.conn.connect((r.group(1), int(r.group(2))))
-                elif filename:
-                        self._cmd = self._cmd_process
-                        if radare2home is not None:
-                                if not os.path.isdir(radare2home):
-                                        raise Exception('`radare2home` passed is invalid, leave it None or put a valid path to r2 folder')
-                                r2e = os.path.join(radare2home, 'radare2')
-                        else:
-                                r2e = 'radare2'
-                        if os.name == 'nt':
-                                # avoid errors on Windows when subprocess messes with name
-                                r2e += '.exe'
-                        cmd = [r2e, "-q0", filename]
-                        cmd = cmd[:1] + flags + cmd[1:]
-                        try:
-                               self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE, bufsize=0)
-                        except:
-                                raise Exception("ERROR: Cannot find radare2 in PATH")
-                        self.process.stdout.read(1)  # Reads initial \x00
-                        # make it non-blocking to speedup reading
-                        self.nonblocking = True
-                        if self.nonblocking:
-                                fd = self.process.stdout.fileno()
-                                if not self.__make_non_blocking(fd):
-                                        Exception('ERROR: Cannot make stdout pipe non-blocking')
+    @staticmethod
+    def __make_non_blocking(fd):
+        if fcntl is not None:
+            fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+            fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+            return True
 
-        @staticmethod
-        def __make_non_blocking(fd):
-                if fcntl is not None:
-                        fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-                        fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-                        return True
+        if os.name != "nt":
+            raise NotImplementedError()
 
-                if os.name != 'nt':
-                        raise NotImplementedError()
+        import msvcrt
+        from ctypes import windll, byref
+        from ctypes.wintypes import HANDLE, DWORD, BOOL
 
-                import msvcrt
-                from ctypes import windll, byref
-                from ctypes.wintypes import HANDLE, DWORD, BOOL
+        try:
+            from ctypes import POINTER
+        except:
+            from ctypes.wintypes import POINTER
+
+        LPDWORD = POINTER(DWORD)
+        SetNamedPipeHandleState = windll.kernel32.SetNamedPipeHandleState
+        SetNamedPipeHandleState.argtypes = [HANDLE, LPDWORD, LPDWORD, LPDWORD]
+        SetNamedPipeHandleState.restype = BOOL
+
+        h = msvcrt.get_osfhandle(fd)
+
+        PIPE_NOWAIT = DWORD(0x00000001)
+        res = windll.kernel32.SetNamedPipeHandleState(h, byref(PIPE_NOWAIT), None, None)
+        return res != 0
+
+    def _cmd_process(self, cmd):
+        cmd = cmd.strip().replace("\n", ";")
+        self.process.stdin.write((cmd + "\n").encode("utf8"))
+        r = self.process.stdout
+        self.process.stdin.flush()
+        out = b""
+        while True:
+            if self.nonblocking:
                 try:
-                        from ctypes import POINTER
+                    foo = r.read(4096)
                 except:
-                        from ctypes.wintypes import POINTER
+                    continue
+            else:
+                foo = r.read(1)
+            if foo:
+                if foo.endswith(b"\0"):
+                    out += foo[:-1]
+                    break
 
-                LPDWORD = POINTER(DWORD)
-                SetNamedPipeHandleState = windll.kernel32.SetNamedPipeHandleState
-                SetNamedPipeHandleState.argtypes = [HANDLE, LPDWORD, LPDWORD, LPDWORD]
-                SetNamedPipeHandleState.restype = BOOL
+                out += foo
+            else:
+                # if there is no any output from pipe this loop will eat CPU, probably we have to do micro-sleep here
+                if self.nonblocking:
+                    time.sleep(0.001)
 
-                h = msvcrt.get_osfhandle(fd)
+        return out.decode("utf-8", errors="ignore")
 
-                PIPE_NOWAIT = DWORD(0x00000001)
-                res = windll.kernel32.SetNamedPipeHandleState(h, byref(PIPE_NOWAIT), None, None)
-                return res != 0
+    def _cmd_http(self, cmd):
+        try:
+            try:
+                quocmd = urllib.parse.quote(cmd)
+            except:
+                quocmd = urllib.quote(cmd)
+            response = urlopen("{uri}/{cmd}".format(uri=self.uri, cmd=quocmd))
+            return response.read().decode("utf-8", errors="ignore")
+        except URLError:
+            pass
+        return None
 
-        def _cmd_process(self, cmd):
-                cmd = cmd.strip().replace("\n", ";")
-                self.process.stdin.write((cmd + '\n').encode('utf8'))
-                r = self.process.stdout
-                self.process.stdin.flush()
-                out = b''
-                while True:
-                        if self.nonblocking:
-                                try:
-                                        foo = r.read(4096)
-                                except:
-                                        continue
-                        else:
-                                foo = r.read(1)
-                        if foo:
-                                if foo.endswith(b'\0'):
-                                        out += foo[:-1]
-                                        break
-
-                                out += foo
-                        else:
-                                # if there is no any output from pipe this loop will eat CPU, probably we have to do micro-sleep here
-                                if self.nonblocking:
-                                        time.sleep(0.001)
-
-                return out.decode('utf-8', errors='ignore')
-
-        def _cmd_http(self, cmd):
-                try:
-                        try:
-                                quocmd = urllib.parse.quote(cmd)
-                        except:
-                                quocmd = urllib.quote(cmd)
-                        response = urlopen('{uri}/{cmd}'.format(uri=self.uri, cmd=quocmd))
-                        return response.read().decode('utf-8', errors='ignore')
-                except URLError:
-                         pass
-                return None
-
-        def _cmd_tcp(self, cmd):
-                res = b''
-                self.conn.sendall(str.encode(cmd, 'utf-8'))
-                data = self.conn.recv(512)
-                while data:
-                        res += data
-                        data = self.conn.recv(512)
-                return res.decode('utf-8', errors='ignore')
+    def _cmd_tcp(self, cmd):
+        res = b""
+        self.conn.sendall(str.encode(cmd, "utf-8"))
+        data = self.conn.recv(512)
+        while data:
+            res += data
+            data = self.conn.recv(512)
+        return res.decode("utf-8", errors="ignore")

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""open_sync.py 
+"""open_sync.py
 This script use code from old __init__.py open object
 
 """
@@ -13,12 +14,8 @@ import sys
 from subprocess import Popen, PIPE
 from .open_base import OpenBase, get_radare_path
 
-if sys.version_info >= (3, 0):
-        from urllib.request import urlopen
-        from urllib.error import URLError
-else:
-        from urllib2 import urlopen
-        from urllib2 import URLError
+from urllib.request import urlopen
+from urllib.error import URLError
 
 try:
         import fcntl
@@ -27,7 +24,7 @@ except ImportError:
 
 
 class open(OpenBase):
-                
+
         def __init__(self, filename='', flags=[], radare2home=None):
                 super(open, self).__init__(filename, flags)
                 if filename.startswith("http://"):
@@ -97,7 +94,7 @@ class open(OpenBase):
                 res = windll.kernel32.SetNamedPipeHandleState(h, byref(PIPE_NOWAIT), None, None)
                 return res != 0
 
-        def _cmd_process(self, cmd): 
+        def _cmd_process(self, cmd):
                 cmd = cmd.strip().replace("\n", ";")
                 self.process.stdin.write((cmd + '\n').encode('utf8'))
                 r = self.process.stdout

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from distutils.core import setup
 import r2pipe
 
@@ -9,7 +10,6 @@ setup(
     version=r2pipe.version(),
     license='MIT',
     description='Pipe interface for radare2',
-#    long_description=readme,
     author='pancake',
     author_email='pancake@nopcode.org',
     url='https://rada.re',

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,17 +2,17 @@
 from distutils.core import setup
 import r2pipe
 
-#with open('README.rst') as readme_file:
+# with open('README.rst') as readme_file:
 #    readme = readme_file.read()
 
 setup(
-    name='r2pipe',
+    name="r2pipe",
     version=r2pipe.version(),
-    license='MIT',
-    description='Pipe interface for radare2',
-    author='pancake',
-    author_email='pancake@nopcode.org',
-    url='https://rada.re',
-    package_dir={'r2pipe': 'r2pipe'},
-    packages=['r2pipe']
+    license="MIT",
+    description="Pipe interface for radare2",
+    author="pancake",
+    author_email="pancake@nopcode.org",
+    url="https://rada.re",
+    package_dir={"r2pipe": "r2pipe"},
+    packages=["r2pipe"],
 )


### PR DESCRIPTION
`#!/usr/bin/env python` on some systems point to python2 executable still. Fixing this, also some Python 3 related fixes, reformatted code with [black](https://github.com/psf/black).