### PR TITLE
Windows r2pipe.py: Don't chop off last char if it's not 0

### DIFF
--- a/python/r2pipe/open_base.py
+++ b/python/r2pipe/open_base.py
@@ -164,7 +164,8 @@ class OpenBase(object):
                 )
                 out += chBuf.value
                 if ord(chBuf[cbRead.value - 1]) == 0:
-                    out = out[0:-1]
+                    if len(out) > 0 and out[-1] == 0:
+                        out = out[0:-1]
                     break
         else:
             os.write(self.pipe[1], cmd.encode())


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr checks first whether the last char of `out` is a `\0` before chopping it off. This fixes the missing newline problem seen in radareorg/radare2#17156.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Try `print(r2.cmd('pdf'), end='')` as the last command in a Windows r2pipe.py script and see whether the last output line is covered up by the r2 prompt.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
