### PR TITLE
r2pipe.go style fixes and cleanups

### DIFF
--- a/go/example/example.go
+++ b/go/example/example.go
@@ -8,6 +8,7 @@ func main() {
 	r2p, err := r2pipe.NewPipe("/bin/ls")
 	if err != nil {
 		print("ERROR: ", err)
+
 		return
 	}
 	defer r2p.Close()

--- a/go/native.go
+++ b/go/native.go
@@ -2,16 +2,20 @@
 
 package r2pipe
 
-import "github.com/rainycape/dl"
-import "errors"
+import (
+	"github.com/rainycape/dl"
+	"errors"
+)
 
 type Ptr = *struct{}
 
-var lib Ptr = nil
-var r_core_new func() Ptr
-var r_core_free func(Ptr)
-var r_mem_free func(interface{})
-var r_core_cmd_str func(Ptr, string) string
+var (
+	lib            Ptr = nil
+	r_core_new     func() Ptr
+	r_core_free    func(Ptr)
+	r_mem_free     func(interface{})
+	r_core_cmd_str func(Ptr, string) string
+)
 
 func NativeLoad() error {
 	if lib != nil {


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Fixes according to the latest `go fmt`, `go lint`, etc - everything through [`golangci-lint`](https://github.com/golangci/golangci-lint).
