### PR TITLE
r2pipe.go: do not use `q!` because of the -1 exit code

### DIFF
--- a/go/r2pipe.go
+++ b/go/r2pipe.go
@@ -210,3 +210,20 @@ func (r2p *Pipe) Close() error {
 
 	return r2p.r2cmd.Wait()
 }
+
+// Forcing shutdown of r2, closing the created pipe.
+func (r2p *Pipe) ForceClose() error {
+	if r2p.close != nil {
+		return r2p.close(r2p)
+	}
+
+	if r2p.File == "" {
+		return nil
+	}
+
+	if _, err := r2p.Cmd("q!"); err != nil {
+		return err
+	}
+
+	return r2p.r2cmd.Wait()
+}

--- a/go/r2pipe.go
+++ b/go/r2pipe.go
@@ -204,7 +204,7 @@ func (r2p *Pipe) Close() error {
 		return nil
 	}
 
-	if _, err := r2p.Cmd("q!"); err != nil {
+	if _, err := r2p.Cmd("q"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently if radare2 executes `q!` it returns -1 exit code
which masks the possible errors when r2pipe.go used.
Changing to `q` will ensure that exit code is 0 in case of success.

