### PR TITLE
Add setBinPath to r2pipe-promise

### DIFF
--- a/nodejs/r2pipe-promise/index.js
+++ b/nodejs/r2pipe-promise/index.js
@@ -12,11 +12,16 @@ class R2Pipe {
 
 module.exports = {
   R2Pipe,
+  setBinPath,
   isAvailable: r2pipe.isAvailable,
   open: openPromise,
   syscmd: makePromise(r2pipe, 'syscmd'),
   syscmdj: makePromise(r2pipe, 'syscmdj')
 };
+
+function setBinPath (path) {
+    r2pipe.r2bin = path;
+}
 
 function openPromise (file, options) {
   return new Promise(function (resolve, reject) {


### PR DESCRIPTION
**Checklist**

- [ ] Mark it when ready to merge
- [ ] Closing issues: #issue
- [ ] I've added tests (optional)

**Description**

r2pipe allows setting the path on the r2bin property,
but it is not exposed by r2pipe-promise
