### PR TITLE
Added better Clojure support and features

### DIFF
--- a/clojure/README.md
+++ b/clojure/README.md
@@ -1,33 +1,106 @@
 # r2pipe.clj
 
-`"Know only Clojure and want to work with r2? I got you fam."`
+`"Know Clojure and want to work with r2? I got you fam."`
 
-r2pipe.clj is a Clojure library to interact with [radare2](https://github.com/radareorg/radare2). This requires you to have r2 installed on your system. It spawns a new process and communicates with it over pipes.
+r2pipe is a Clojure library to interact with [radare2](https://github.com/radareorg/radare2). This requires you to have r2 installed on your system. It spawns a new process and communicates with it over pipes.
 
 ## Installation
 
 In Leiningen:
 
-[![Clojars Project](https://img.shields.io/clojars/v/org.clojars.chinmay_dd/r2pipe.svg)](https://clojars.org/org.clojars.chinmay_dd/r2pipe)
+TBD
 
 ## Usage
 
+The basic usage for this is to use a default r2 instance.
+
 ```clojure
-;; Start up the REPL and include r2 pipe lib
-user=> (require '[r2pipe.core :refer :all])
+;; Basic usage:
+(use 'r2pipe.core)
 
-;; Configure the r2 path. It will default to "/usr/bin/r2".
-user=> (configure-path "/usr/bin/r2")
+(r2open "spawn:///./program.bin")    ; for spawning r2, opening this file
+(r2open "tcp://127.0.0.1:1337")      ; for using a TCP connection
+(r2open "http://127.0.0.1:9090/cmd") ; for using HTTP
 
-;; Open the file into r2
-user=> (r2open "binary")
-#'r2pipe.core/pipe
+(cmd "pd" "8")   ; returns a string representation
+(cmdj "pdj" "8") ; returns a Clojure map
 
-;; Execute a command in r2
-user=> (r2cmd "pi 5")
-"xor ebp, ebp\npop esi\nmov ecx, esp\nand esp, 0xfffffff0\npush eax\n"
+(close) ; closes/cleans the pipe
+
+;; To allow inquiries (i.e: "pd?")
+(require '[r2pipe.proto :as proto])
+(proto/set-deny-inquiry false)
+
+;; To change the default location of the radare2 binary
+(configure-path "/usr/bin/r2")
 ```
 
-### Todo
+Alternatively, if you would like to use a specific protocol, or to have multiple
+instances, the library can be used like this:
 
-A lot of things!
+
+```clojure
+(require '[r2pipe.proto :as r2]) ; necessary for 'cmd' and 'cmdj'
+
+;;
+;; Spawning example
+;;
+
+(require '[r2pipe.spawn :as spawn])
+(def i (spawn/r2open "/bin/ls" "/usr/bin/r2"))
+
+(r2/cmd i "pd" "8")
+(r2/cmdj i "pdj" "8")
+
+(.close i)
+
+;;
+;; TCP example
+;;
+
+;; Note: radare2 drops the connection after a command, so for
+;; each write there will be an opened connection, and after 
+;; a read, the connection is closed
+
+(require '[r2pipe.tcp :as tcp]) ; for TCP
+(def i (tcp/r2open "127.0.0.1" 1337))
+
+(r2/cmd i "pd" "8")
+(r2/cmdj i "pdj" "8")
+
+(.close i)
+
+;;
+;; HTTP example
+;;
+
+(require '[r2pipe.http :as http]) ; for HTTP
+(def i (http/r2open "http://127.0.0.1:9090/cmd"))
+
+(r2/cmd i "pd" "8")
+(r2/cmdj i "pdj" "8")
+
+(.close i)
+```
+
+For the pipe instances, you can also manually send
+the commands, by using the `R2Pipe` protocol's methods:
+
+N.B: queues for messages are not supported yet except
+for spawning pipes (more or less by accident? they're not even queues tbh),
+i.e: you can only read one message after a write, and nothing if no
+write occured
+
+```clojure
+(.r2-write i "pdj 8")
+(.r2-read i)
+(.close i)
+```
+
+### TODO
+
+- Queues
+- Tests
+- ClojureScript support
+- Async (only for TCP and HTTP most probably)
+- RAP

--- a/clojure/project.clj
+++ b/clojure/project.clj
@@ -1,7 +1,11 @@
-(defproject org.clojars.chinmay_dd/r2pipe "0.0.2"
-  :description "Communicate to Radare2 via pipes"
+(defproject org.radare/r2pipe "0.5.1"
+  :description "Communicate with radare2 via pipes"
+  :license "MIT"
+  :url "https://radare.org/"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [me.raynes/conch "0.8.0"]]
-
-  :plugins      [[lein-codox "0.9.5"]]
-  )
+                 
+                 [cheshire "5.10.0"]
+                 
+                 [me.raynes/conch "0.8.0"]
+                 [clj-http "3.12.0"]])
+;; :plugins      [[lein-codox "0.9.5"]] ; code as documentation for now?

--- a/clojure/src/r2pipe/http.clj
+++ b/clojure/src/r2pipe/http.clj
@@ -1,0 +1,50 @@
+(ns r2pipe.http
+  (:refer-clojure :exclude [read-string])
+  (:require [r2pipe.proto :as r2p]
+            [clojure.string :as string]
+            [clj-http.client :as client]))
+
+(defrecord HTTPClientData [scheme server port base-uri last-response])
+
+(deftype R2HTTP [^HTTPClientData ^:volatile-mutable client-data]
+  r2p/R2Proto
+  (r2-read [this]
+    "Read last response of r2 HTTP server"
+    (let [response (:last-response client-data)]
+      (.close this)
+      response))
+  
+  (r2-write [this input]
+    "Write request r2 HTTP server"
+    (let [full-uri
+          (string/join `(~(:base-uri client-data)
+                         ~(if (string/ends-with? (:base-uri client-data) "/") "" "/")
+                         ~(client/url-encode-illegal-characters input)))
+          full-url (client/unparse-url
+                    {:scheme (:scheme client-data)
+                     :server-name (:server client-data)
+                     :server-port (:port client-data)
+                     :uri full-uri})
+          response (client/get full-url)]
+      (if (not (= 200 (:status response)))
+        (ex-info "request in error"
+                 {:status (:status response)
+                  :input input :url full-url
+                  :response response}))
+      (set! client-data (assoc client-data :last-response (:body response)))
+      nil))
+  
+  (close [this]
+    "Closes r2 HTTP client (does nothing really)"
+    (set! client-data (assoc client-data :last-response nil))))
+
+(defn r2open
+  "Creates the HTTP connection client"
+  [url]
+  (let [parsed-url (client/parse-url url)]
+    (R2HTTP. (->HTTPClientData
+              (:scheme parsed-url)
+              (:server-name parsed-url)
+              (:server-port parsed-url)
+              (:uri parsed-url)
+              nil))))

--- a/clojure/src/r2pipe/proto.clj
+++ b/clojure/src/r2pipe/proto.clj
@@ -1,0 +1,34 @@
+(ns r2pipe.proto
+    (:require [clojure.string :as string]
+              [cheshire.core :refer :all]))
+
+(def deny-inquiry true)
+
+(defn set-deny-inquiry
+  [deny]
+  (def deny-inquiry deny))
+
+(defprotocol R2Proto
+  (r2-read [this])
+  (r2-write [this input]) ; will specific serialization be required?
+  (close [this]))
+
+(defn cmd [this & cmds]
+  "Generic function to send to an R2 pipe a command"
+  (let [cmd (first (string/split (first cmds) #"\s+"))
+        msg (string/join " " cmds)]
+    (if (and deny-inquiry (string/includes? cmd "?"))
+      (throw (ex-info "inquiry command" {:cmd cmd :cmds cmds})))
+    (.r2-write this msg)
+    (.r2-read this)))
+
+(defn cmdj [this & cmds]
+  "Generic function to send to an R2 pipe a command and receive a JSON"
+  (let [cmd (first (string/split (first cmds) #"\s+"))
+        msg (string/join " " cmds)]
+    (if (and deny-inquiry (string/includes? cmd "?"))
+      (throw (ex-info "inquiry command" {:cmd cmd :cmds cmds})))
+    (if (not (string/ends-with? cmd "j"))
+      (throw (ex-info "not a json command" {:cmd cmd :cmds cmds})))
+    (.r2-write this msg)
+    (parse-string (.r2-read this) true)))

--- a/clojure/src/r2pipe/spawn.clj
+++ b/clojure/src/r2pipe/spawn.clj
@@ -1,0 +1,36 @@
+(ns r2pipe.spawn
+  (:require [r2pipe.proto :as r2p]
+            
+            [me.raynes.conch.low-level :as sh]))
+
+(def cmd-delim (char 0))
+
+(deftype R2Spawn [proc]
+  r2p/R2Proto
+  (r2-read [this]
+    "Read from the r2 process"
+    (apply str
+           (take-while
+            (fn [c] (not (= c (str cmd-delim))))
+            (repeatedly
+             #(-> proc :out .read char str)))))
+  
+  (r2-write [this input]
+    "Write to the r2 process"
+    (.write (:in proc) (.getBytes (str input "\n")))
+    (.flush (:in proc)))
+  
+  (close [this]
+    "Close r2 process"
+    (-> proc :process .destroy)
+    (:process proc)))
+
+(defn r2open
+  "Opens a file in r2 and starts a process instance"
+  [filename r2-path]
+  (let [proc (sh/proc r2-path
+                      "-q0" "-e" "scr.utf8=false"
+                      (str filename))
+        p (R2Spawn. proc)]
+    (.r2-read p) ;; first prompt must go
+    p))

--- a/clojure/src/r2pipe/tcp.clj
+++ b/clojure/src/r2pipe/tcp.clj
@@ -1,0 +1,61 @@
+(ns r2pipe.tcp
+  (:refer-clojure :exclude [read-string])
+  (:require [r2pipe.proto :as r2p])
+  (:import [java.net Socket]))
+
+(def cmd-delim -1)
+
+(defrecord TCPClient [host port socket])
+
+(defn- is-connected? [^TCPClient client] (-> client :socket nil? not))
+
+;; this would be nice to async ;) todo: create a pool
+(defn- connect [^TCPClient client]
+  "Connect the client to a new TCP stream"
+  (if (is-connected? client)
+    (do
+      (ex-info "connection already in progress" {:client client})
+      client)
+    (assoc client :socket (Socket. (:host client) (:port client)))))
+
+(defn- disconnect [^TCPClient client]
+  "Disconnect the client from the TCP stream"
+  (if (-> client :socket nil? not)
+    (do
+      (-> client :socket .close)
+      (assoc client :socket nil))
+    client))
+
+(deftype R2TCP [^TCPClient ^:volatile-mutable client]
+  r2p/R2Proto
+  (r2-read [this]
+    "Read from the r2 TCP stream"
+    (if (is-connected? client)
+      (let [s-out (-> client :socket .getInputStream)
+            output
+            (apply
+             str
+             (map (fn [c] (char c))
+                  (take-while
+                   (fn [c] (not (= c cmd-delim)))
+                   (repeatedly
+                    #(-> s-out .read)))))]
+        (.close this)
+        output)
+      nil))
+  
+  (r2-write [this input]
+    "Write to the r2 TCP stream"
+    (set! client (connect client))
+    (let [s-in (-> client :socket .getOutputStream)]
+      (.write s-in (.getBytes (str input "\n")))
+      (.flush s-in)))
+  
+  (close [this]
+    "Close r2 TCP connection, if possible"
+    (set! client (disconnect client))))
+
+(defn r2open
+  "Creates the TCP connection client"
+  [host port]
+  (R2TCP. (->TCPClient host port nil)))


### PR DESCRIPTION
I have added features for the Clojure r2pipe, which can be found below.

For having the Clojure r2pipe library on Clojars, it would be ideal if the org name would be "org.radare". From what I've read it requires an account on Clojars, a TXT record, a GPG key for signing, and some time. Will ask around politely, if this is worth it/not too time consuming.

**Features**

- proper spawn processing (NUL as prompt)
- JSON deserialization
- TCP pipes
- HTTP pipes
