### PR TITLE
Do not turn off cache usage when invalidate_cache is called

### DIFF
--- a/python/r2pipe/open_base.py
+++ b/python/r2pipe/open_base.py
@@ -152,7 +152,6 @@ class OpenBase(object):
             raise Exception("ERROR: Cannot use #!pipe without R2PIPE_{IN|OUT} env")
 
     def invalidate_cache(self):
-        self.use_cache = False
         self.cache = {}
 
     def _cmd_pipe(self, cmd):


### PR DESCRIPTION
**Checklist**

- [x ] Mark it when ready to merge
- [ ] Closing issues: #issue
- [ ] I've added tests (optional)

Clearing the cache should not turn it off for future usages.
