### PR TITLE
Improve cmdj and cmdjf to allow a user defined struct as argument

### DIFF
--- a/go/r2pipe.go
+++ b/go/r2pipe.go
@@ -195,17 +195,33 @@ func (r2p *Pipe) Cmdf(f string, args ...interface{}) (string, error) {
 
 // Cmdj acts like Cmd but interprets the output of the command as json. It
 // returns the parsed json keys and values.
-func (r2p *Pipe) Cmdj(cmd string, out interface{}) (err error) {
+func (r2p *Pipe) Cmdj(cmd string) (out interface{}, err error) {
 	rstr, err := r2p.Cmd(cmd)
+	if err == nil {
+		err = json.Unmarshal([]byte(rstr), out)
+	}
+	return out, err
+}
+
+// CmdjStruct acts like Cmdjs but it will fill the interface/struct with the wanted values. It
+// returns the command execution error.
+func (r2p *Pipe) CmdjStruct(cmd string, out interface{}) (err error) {
+	rstr, err := r2p.Cmd(cmd)
+
 	if err == nil {
 		err = json.Unmarshal([]byte(rstr), out)
 	}
 	return err
 }
 
-// like cmdj but formats the command
-func (r2p *Pipe) Cmdjf(f string, out interface{}, args ...interface{}) (err error) {
-	return r2p.Cmdj(fmt.Sprintf(f, args...), out)
+//like cmdj but formats the command
+func (r2p *Pipe) Cmdjf(f string, args ...interface{}) (interface{}, error) {
+	return r2p.Cmdj(fmt.Sprintf(f, args...))
+}
+
+// like Cmdj, but besides format the command it will already fill the interface sent
+func (r2p *Pipe) CmdjfStruct(f string, out interface{}, args ...interface{}) error {
+	return r2p.CmdjStruct(fmt.Sprintf(f, args...), out)
 }
 
 // Close shuts down r2, closing the created pipe.

--- a/go/r2pipe.go
+++ b/go/r2pipe.go
@@ -195,17 +195,17 @@ func (r2p *Pipe) Cmdf(f string, args ...interface{}) (string, error) {
 
 // Cmdj acts like Cmd but interprets the output of the command as json. It
 // returns the parsed json keys and values.
-func (r2p *Pipe) Cmdj(cmd string) (out interface{}, err error) {
+func (r2p *Pipe) Cmdj(cmd string, out interface{}) (err error) {
 	rstr, err := r2p.Cmd(cmd)
 	if err == nil {
 		err = json.Unmarshal([]byte(rstr), out)
 	}
-	return out, err
+	return err
 }
 
-//like cmdj but formats the command
-func (r2p *Pipe) Cmdjf(f string, args ...interface{}) (interface{}, error) {
-	return r2p.Cmdj(fmt.Sprintf(f, args...))
+// like cmdj but formats the command
+func (r2p *Pipe) Cmdjf(f string, out interface{}, args ...interface{}) (err error) {
+	return r2p.Cmdj(fmt.Sprintf(f, args...), out)
 }
 
 // Close shuts down r2, closing the created pipe.

--- a/go/r2pipe_test.go
+++ b/go/r2pipe_test.go
@@ -2,8 +2,15 @@
 
 package r2pipe
 
-import "testing"
-import "fmt"
+import (
+	"fmt"
+	"testing"
+)
+
+type Offset struct {
+	Offset  uint
+	Current bool
+}
 
 func TestCmd(t *testing.T) {
 	fmt.Println("[*] Testing r2 spawn pipe")
@@ -25,5 +32,17 @@ func TestCmd(t *testing.T) {
 	}
 	if buf != check {
 		t.Errorf("buf=%v; want=%v", buf, check)
+	}
+
+	offset := Offset{}
+	r2p.CmdjStruct("sj ~{0}", &offset)
+
+	if !offset.Current {
+		t.Errorf("CurrentOffset=%v; want=%v", offset.Current, true)
+	}
+
+	r2p.CmdjfStruct("sj ~{%d}", &offset, 0)
+	if !offset.Current {
+		t.Errorf("CurrentOffset=%v; want=%v", offset.Current, true)
 	}
 }


### PR DESCRIPTION
**Checklist**

- [ x] Mark it when ready to merge
- [ x] I've added tests (optional)

**Description**
`cmdj` and `cmdj` returns an interface, a better approach is to let the developer sent an already known struct type and works just like the `json.Unmarshal` method.

```golang
inst := Instruction{}
r2.Cmdjf("pdj %d @ %d ~{0}", &inst, numOpcodes, address)
```

Where the struct `Instruction` is an already built struct with the required fields from the json response.
