### PR TITLE
Python win10 pipe fix

### DIFF
--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -129,19 +129,26 @@ class open(OpenBase):
         while True:
             if self.nonblocking:
                 try:
+                    null_start = False
                     if len(self.pending) > 0:
                         foo = self.pending
                         self.pending = b""
                     else:
                         foo = r.read(4096)
-                    if foo is not None:
+                        if os.name == "nt":
+                            if foo.startswith(b"\x00"):
+                                foo = foo[1:]
+                                null_start = True
+                    if foo:
                         zro = foo.find(b"\x00")
                         if zro != -1:
                             out += foo[0:zro]
-                            if zro < len(foo):
+                            if zro  < len(foo):
                                 self.pending = foo[zro + 1:]
                             break
                         out += foo
+                    elif null_start:
+                        break
                 except:
                     pass
             else:

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -32,6 +32,7 @@ except ImportError:
 class open(OpenBase):
     def __init__(self, filename="", flags=[], radare2home=None):
         super(open, self).__init__(filename, flags)
+        self.pipe_read_sleep = 0.001
         self.pending = b''
         if filename.startswith("http://"):
             self._cmd = self._cmd_http
@@ -149,7 +150,7 @@ class open(OpenBase):
                     if foo == b"\x00":
                         break
                     out += foo
-            time.sleep(0.001)
+            time.sleep(self.pipe_read_sleep)
         return out.decode("utf-8", errors="ignore")
 
     def _cmd_http(self, cmd):


### PR DESCRIPTION
**Checklist**

- [ ] Mark it when ready to merge
- [ ] Closing issues: #issue
- [ ] I've added tests (optional)

**Description**

This is for [issue 146](https://github.com/radareorg/radare2-r2pipe/issues/146) - in Windows 10 (and possibly other Windows, haven't checked), command results only come when the next command is issued (so if I run a command, I'll get empty output, and will get the actual output only when I run another command, instead of the new command's output). This seems to be due to a null byte that gets prepended to the pipe read output at position 0. I added some code to try and handle that, and it seems to work in my PC
I also changed the sleep time to a variable, because I noticed that sometimes command results do not return (regardless of the null byte) and that by increasing the sleep the reliability increases