### PR TITLE
DotNet: Fix incorrect end of stream check in RunCommand

### DIFF
--- a/dotnet/r2pipe/R2Pipe.cs
+++ b/dotnet/r2pipe/R2Pipe.cs
@@ -101,12 +101,12 @@ namespace r2pipe
             
             while (true)
             {
-                char buffer = (char)r2Process.StandardOutput.Read();
+                int buffer = r2Process.StandardOutput.Read();
 
-                if (buffer == 0x00)
+                if (buffer == -1)
                     break;
 
-                sb.Append(buffer);
+                sb.Append((char)buffer);
             }
             return sb.ToString();
         }


### PR DESCRIPTION
**Checklist**

- [ ] Mark it when ready to merge
- [ ] Closing issues: #issue
- [ ] I've added tests (optional)

**Description**

Hello - not sure if anyone uses the DotNet bindings, but on closing it never terminates (until a memory leak becomes too fatal).

#### To reproduce

```csharp
using r2pipe;

using (IR2Pipe pipe = new R2Pipe(@"C:\Windows\notepad.exe", @"C:\radare2\radare2.exe"))
{
    Task<string> async = pipe.RunCommandAsync("?V");
    Console.WriteLine("Hello async r2!" + async.Result);
}

#### Output

The expected message, but the program never terminates and memory usage constantly increases
```
![image](https://user-images.githubusercontent.com/5470374/185721496-ba427cc2-734c-4249-a774-45ff6933689d.png)

#### Root cause


```csharp
        public string RunCommand(string command)
        {
            var sb = new StringBuilder();
            r2Process.StandardInput.WriteLine(command);
            r2Process.StandardInput.Flush();
            
            while (true)
            {
                char buffer = (char)r2Process.StandardOutput.Read();

                if (buffer == 0x00)
                    break;

                sb.Append(buffer);
            }
            return sb.ToString();
        }
```

When the Dispose operation calls the q command, RunCommand waits for the end of the stream by checking for a 0 result. [StreamReader.Read()](https://docs.microsoft.com/en-us/dotnet/api/system.io.streamreader.read?view=net-6.0#system-io-streamreader-read ) doesn't return 0 when there is nothing left though, it returns -1.

This PR just changes the check to look for -1, so it now exits as expected. 



