### PR TITLE
Nullbyte bugfix

### DIFF
--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -7,7 +7,6 @@ This script use code from old __init__.py open object
 
 import re
 import socket
-import time
 import urllib
 import os
 from subprocess import Popen, PIPE

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -71,12 +71,7 @@ class open(OpenBase):
                 )
             except:
                 raise Exception("ERROR: Cannot find radare2 in PATH")
-            # make it non-blocking to speedup reading
-            self.nonblocking = False
-            if self.nonblocking:
-                fd = self.process.stdout.fileno()
-                if not self.__make_non_blocking(fd):
-                    Exception("ERROR: Cannot make stdout pipe non-blocking")
+
             if hello_cmd:
                 self.process.stdout.read(1)  # Reads initial \x00
                 try:
@@ -131,37 +126,29 @@ class open(OpenBase):
         out = b""
         foo = None
         while True:
-            if self.nonblocking:
-                try:
-                    null_start = False
-                    if len(self.pending) > 0:
-                        foo = self.pending
-                        self.pending = b""
-                    else:
-                        foo = r.read(4096)
-                        if os.name == "nt":
-                            if foo.startswith(b"\x00"):
-                                foo = foo[1:]
-                                null_start = True
-                    if foo:
-                        zro = foo.find(b"\x00")
-                        if zro != -1:
-                            out += foo[0:zro]
-                            if zro  < len(foo):
-                                self.pending = foo[zro + 1:]
-                            break
-                        out += foo
-                    elif null_start:
-                        break
-                except:
-                    pass
-            else:
-                foo = r.read(1)
-                if foo is not None:
-                    if foo == b"\x00":
+            try:
+                null_start = False
+                if len(self.pending) > 0:
+                    foo = self.pending
+                    self.pending = b""
+                else:
+                    foo = r.read(4096)
+                    if os.name == "nt":
+                        if foo.startswith(b"\x00"):
+                            foo = foo[1:]
+                            null_start = True
+                if foo:
+                    zro = foo.find(b"\x00")
+                    if zro != -1:
+                        out += foo[0:zro]
+                        if zro  < len(foo):
+                            self.pending = foo[zro + 1:]
                         break
                     out += foo
-            time.sleep(self.pipe_read_sleep)
+                elif null_start:
+                    break
+            except:
+                pass
         return out.decode("utf-8", errors="ignore")
 
     def _cmd_http(self, cmd):

--- a/python/test/test_integration.py
+++ b/python/test/test_integration.py
@@ -88,3 +88,9 @@ class TestR2PipeIntegration(unittest.TestCase):
         res = self.r2.cmd(cmd)
         self.assertEqual(res, expected)
 
+    def test_r2cmd_no_nullbyte_bug(self):
+        import r2pipe
+        r = r2pipe.open('/bin/ls')
+
+        result = r.cmd('prx @ rsp')
+        self.assertNotEqual(result, '')


### PR DESCRIPTION
Remove unused variable self.nonblocking, use bulk read 4096 instead of byte by byte, remove sleep that slows everything down a lot.

**Checklist**

- [x] Mark it when ready to merge
- [ ] Closing issues: #issue
- [x] I've added tests (optional)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
