### PR TITLE
Treat running out of bytes the same as a failed match, like takeWhile in base does, instead of crashing

### DIFF
--- a/haskell/R2Pipe.hs
+++ b/haskell/R2Pipe.hs
@@ -20,10 +20,10 @@ stringToLBS = L.pack . map (fromIntegral . ord)
 
 lHTakeWhile :: (Word8 -> Bool) -> Handle -> IO L.ByteString
 lHTakeWhile p h = do
-    c <- fmap L.head $ L.hGet h 1
-    if p c
-        then fmap (c `L.cons`) $ lHTakeWhile p h
-        else return L.empty
+    c <- fmap L.uncons $ L.hGet h 1
+    case c of
+        Just (j, _) | p j -> fmap (j `L.cons`) $ lHTakeWhile p h
+        _ -> return L.empty
 
 data R2Context = HttpCtx String
                | PipeCtx Handle Handle


### PR DESCRIPTION
**Checklist**

- [x] Mark it when ready to merge
- [ ] Closing issues: #issue
- [ ] I've added tests (optional)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

See the Stack Overflow question [Different behavior in GHCI and GHC (Running radare2 pipe)](https://stackoverflow.com/q/77331169/7509065) for context. When the real `takeWhile` runs out of elements, it stops gracefully the same as if it found an element that didn't match its predicate. This change makes us do the same thing, instead of crashing.