### PR TITLE
fix: Improve error handling to avoid infinite loop

### DIFF
--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -129,9 +129,9 @@ class open(OpenBase):
         out = bytearray()
         foo = None
         while True:
+            if self.process.poll() == -11:
+                raise RuntimeError(f'Segmentation fault detected {self.process}')
             try:
-                if self.process.poll() == -11:
-                    raise RuntimeError(f'Segmentation fault detected {self.process}')
                 null_start = False
                 if len(self.pending) > 0:
                     foo = self.pending
@@ -152,8 +152,7 @@ class open(OpenBase):
                     out += foo
                 elif null_start:
                     break
-            except RuntimeError as e:
-                raise e
+
             except KeyboardInterrupt:
                 os.kill(os.getpid(), signal.SIGINT)
             except:

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -6,6 +6,7 @@ This script use code from old __init__.py open object
 """
 
 import re
+import signal
 import socket
 import urllib
 import os
@@ -129,6 +130,8 @@ class open(OpenBase):
         foo = None
         while True:
             try:
+                if self.process.poll() == -11:
+                    raise RuntimeError(f'Segmentation fault detected {self.process}')
                 null_start = False
                 if len(self.pending) > 0:
                     foo = self.pending
@@ -149,6 +152,10 @@ class open(OpenBase):
                     out += foo
                 elif null_start:
                     break
+            except RuntimeError as e:
+                raise e
+            except KeyboardInterrupt:
+                os.kill(os.getpid(), signal.SIGINT)
             except:
                 pass
         return out.decode("utf-8", errors="ignore")

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -6,7 +6,6 @@ This script use code from old __init__.py open object
 """
 
 import re
-import signal
 import socket
 import urllib
 import os
@@ -153,8 +152,8 @@ class open(OpenBase):
                 elif null_start:
                     break
 
-            except KeyboardInterrupt:
-                os.kill(os.getpid(), signal.SIGINT)
+            except KeyboardInterrupt as e:
+                raise e
             except:
                 pass
         return out.decode("utf-8", errors="ignore")

--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -128,8 +128,8 @@ class open(OpenBase):
         out = bytearray()
         foo = None
         while True:
-            if self.process.poll() == -11:
-                raise RuntimeError(f'Segmentation fault detected {self.process}')
+            if self.process.poll() is not None:
+                raise RuntimeError(f"Process terminated unexpectedly trying to run the command {cmd}\n{self.process}")
             try:
                 null_start = False
                 if len(self.pending) > 0:


### PR DESCRIPTION
**Checklist**

- [ ] Mark it when ready to merge
- [ ] Closing issues: #issue
- [ ] I've added tests (optional)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

If the subprocess crashed, we got stuck in an infinite loop because of the bare `except` clause.
```python
while True:
  # no way to get out of this loop unless we hit a `break` somewhere
  except:
    pass
```

This change handles SIGINT (`KeyboardInterrupt`)  instead of ignoring it, which allows the user to press `ctrl-c` to escape the infinite loop.

This change also `poll()`s the subprocess and raises an exception if the process segfaulted. This prevents an infinite loop where we would try to read from a crashed process forever.
